### PR TITLE
fix: 修复左侧设备栏滚动布局

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -475,6 +475,89 @@ a:hover {
     line-height: 56px !important;
 }
 
+.app-shell {
+    height: 100vh;
+    overflow: hidden;
+}
+
+.app-body {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.app-sider {
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.app-sider .ant-layout-sider-children {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.sidebar-tabs.ant-tabs {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.sidebar-tabs .ant-tabs-nav {
+    flex: 0 0 auto;
+    margin: 0 !important;
+}
+
+.sidebar-tabs .ant-tabs-content-holder {
+    flex: 1;
+    min-height: 0;
+}
+
+.sidebar-tabs .ant-tabs-content {
+    height: 100%;
+}
+
+.sidebar-tabs .ant-tabs-tabpane {
+    height: 100%;
+}
+
+.sidebar-tabs .ant-tabs-tabpane-active {
+    display: flex;
+    min-height: 0;
+}
+
+.sidebar-tabs .ant-tabs-tabpane-active > * {
+    flex: 1;
+    min-height: 0;
+}
+
+.app-content {
+    display: flex;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.app-main-grid {
+    flex: 1;
+    height: 100%;
+    min-height: 0;
+}
+
+.app-main-grid > * {
+    min-height: 0;
+}
+
+.app-chat-panel {
+    min-height: 0;
+}
+
+.app-session-panel {
+    min-height: 0;
+}
+
 /* Sider 折叠按钮暗色 */
 .ant-layout-sider-trigger {
     background: rgba(255, 255, 255, 0.04) !important;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -215,7 +215,7 @@ export default function HomePage() {
     }
 
     return (
-        <Layout style={{minHeight: '100vh', background: 'var(--bg-deep)'}}>
+        <Layout className="app-shell" style={{background: 'var(--bg-deep)'}}>
             {/* 顶栏 */}
             <Header style={{
                 padding: '0 24px',
@@ -260,9 +260,10 @@ export default function HomePage() {
                 </Space>
             </Header>
 
-            <Layout>
+            <Layout className="app-body">
                 {/* 左侧边栏 */}
                 <Sider
+                    className="app-sider"
                     width={300}
                     collapsible
                     collapsed={collapsed}
@@ -275,6 +276,7 @@ export default function HomePage() {
                 >
                     {!collapsed ? (
                         <Tabs
+                            className="sidebar-tabs"
                             defaultActiveKey="devices"
                             onChange={handleTabChange}
                             centered
@@ -315,15 +317,11 @@ export default function HomePage() {
                 </Sider>
 
                 {/* 主内容区 */}
-                <Content style={{padding: 16, background: 'var(--bg-deep)'}}>
-                    <div style={{
-                        display: 'flex',
-                        gap: 12,
-                        height: 'calc(100vh - 56px - 32px)',
-                    }}>
+                <Content className="app-content" style={{padding: 16, background: 'var(--bg-deep)'}}>
+                    <div className="app-main-grid" style={{display: 'flex', gap: 12}}>
                         {/* 聊天区 */}
                         <div
-                            className="glass-panel"
+                            className="glass-panel app-chat-panel"
                             style={{
                                 flex: 1,
                                 borderRadius: 'var(--radius-lg)',
@@ -343,7 +341,7 @@ export default function HomePage() {
 
                         {/* Session 面板 */}
                         <div
-                            className="glass-panel"
+                            className="glass-panel app-session-panel"
                             style={{
                                 width: 300,
                                 borderRadius: 'var(--radius-lg)',

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -527,7 +527,7 @@ export default function Chat({
     };
 
     return (
-        <div style={{height: '100%', display: 'flex', flexDirection: 'column'}}>
+        <div style={{height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column'}}>
             {/* 顶栏 */}
             <div style={{
                 padding: '14px 20px',
@@ -553,7 +553,7 @@ export default function Chat({
             </div>
 
             {/* 消息区 */}
-            <div ref={messagesContainerRef} style={{flex: 1, overflow: 'auto', padding: '20px 24px'}}>
+            <div ref={messagesContainerRef} style={{flex: 1, minHeight: 0, overflow: 'auto', padding: '20px 24px'}}>
                 {messages.length === 0 && !isLoading && (
                     <div style={{
                         textAlign: 'center', padding: '60px 20px',

--- a/src/components/DevicePanel.tsx
+++ b/src/components/DevicePanel.tsx
@@ -114,7 +114,7 @@ export default function DevicePanel({
     }
 
     return (
-        <div style={{height: '100%', display: 'flex', flexDirection: 'column'}}>
+        <div style={{height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column'}}>
             {/* 头部 */}
             <div style={{padding: '16px', borderBottom: '1px solid #f0f0f0'}}>
                 <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12}}>
@@ -147,7 +147,7 @@ export default function DevicePanel({
             </div>
 
             {/* 设备列表 */}
-            <div style={{flex: 1, overflow: 'auto', padding: '0 16px'}}>
+            <div style={{flex: 1, minHeight: 0, overflow: 'auto', padding: '0 16px'}}>
                 {propLoading ? (
                     <div style={{textAlign: 'center', padding: 40}}>
                         <Spin indicator={<LoadingOutlined style={{fontSize: 24}} spin/>}/>

--- a/src/components/GraphPanel.tsx
+++ b/src/components/GraphPanel.tsx
@@ -75,7 +75,7 @@ export default function GraphPanel({
                                        onDelete,
                                    }: GraphPanelProps) {
     return (
-        <div style={{height: '100%', display: 'flex', flexDirection: 'column'}}>
+        <div style={{height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column'}}>
             {/* 头部 */}
             <div style={{padding: '12px 0', borderBottom: '1px solid #f0f0f0'}}>
                 <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
@@ -98,7 +98,7 @@ export default function GraphPanel({
             </div>
 
             {/* Graph 列表 */}
-            <div style={{flex: 1, overflow: 'auto'}}>
+            <div style={{flex: 1, minHeight: 0, overflow: 'auto'}}>
                 {loading ? (
                     <div style={{textAlign: 'center', padding: 40}}>
                         <Spin/>

--- a/src/components/SessionPanel.tsx
+++ b/src/components/SessionPanel.tsx
@@ -51,7 +51,7 @@ export default function SessionPanel({
                                          onSelectSession, onDeleteSession, onNewSession, onRefresh,
                                      }: SessionPanelProps) {
     return (
-        <div style={{height: '100%', display: 'flex', flexDirection: 'column'}}>
+        <div style={{height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column'}}>
             {/* 头部 */}
             <div style={{
                 padding: '16px 16px 12px',
@@ -90,7 +90,7 @@ export default function SessionPanel({
             </div>
 
             {/* Session 列表 */}
-            <div style={{flex: 1, overflow: 'auto', padding: '8px'}}>
+            <div style={{flex: 1, minHeight: 0, overflow: 'auto', padding: '8px'}}>
                 {loading ? (
                     <div style={{textAlign: 'center', padding: 40}}>
                         <Spin indicator={<SyncOutlined style={{fontSize: 20, color: '#818cf8'}} spin/>}/>

--- a/src/test-layout-scroll.ts
+++ b/src/test-layout-scroll.ts
@@ -1,0 +1,41 @@
+import {readFileSync} from 'node:fs';
+import path from 'node:path';
+
+function read(relativePath: string): string {
+    return readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+}
+
+function assertIncludes(source: string, expected: string, message: string): void {
+    if (!source.includes(expected)) {
+        throw new Error(message);
+    }
+}
+
+const pageSource = read('src/app/page.tsx');
+const cssSource = read('src/app/globals.css');
+const devicePanelSource = read('src/components/DevicePanel.tsx');
+
+assertIncludes(pageSource, 'className="app-shell"', '缺少 app-shell，页面未锁定为独立视口布局');
+assertIncludes(pageSource, 'className="app-body"', '缺少 app-body，主区域没有可收缩高度容器');
+assertIncludes(pageSource, 'className="app-sider"', '缺少 app-sider，左侧边栏没有独立高度约束');
+assertIncludes(pageSource, 'className="sidebar-tabs"', '缺少 sidebar-tabs，Tabs 容器无法建立 100% 高度链');
+assertIncludes(pageSource, 'className="app-content"', '缺少 app-content，内容区没有独立 overflow 约束');
+assertIncludes(pageSource, 'className="app-main-grid"', '缺少 app-main-grid，主内容行缺少统一高度约束');
+assertIncludes(pageSource, 'className="glass-panel app-chat-panel"', '缺少 app-chat-panel，聊天面板无法继承可收缩高度');
+assertIncludes(pageSource, 'className="glass-panel app-session-panel"', '缺少 app-session-panel，会话面板无法继承可收缩高度');
+
+assertIncludes(cssSource, '.app-shell {', 'globals.css 缺少 app-shell 规则');
+assertIncludes(cssSource, '.app-body {', 'globals.css 缺少 app-body 规则');
+assertIncludes(cssSource, '.app-sider {', 'globals.css 缺少 app-sider 规则');
+assertIncludes(cssSource, '.sidebar-tabs.ant-tabs {', 'globals.css 缺少 sidebar-tabs 规则');
+assertIncludes(cssSource, '.sidebar-tabs .ant-tabs-content-holder {', 'globals.css 缺少 Tabs content-holder 高度约束');
+assertIncludes(cssSource, '.sidebar-tabs .ant-tabs-tabpane-active {', 'globals.css 缺少激活 tab 的 flex 约束');
+assertIncludes(cssSource, '.sidebar-tabs .ant-tabs-tabpane-active > * {', 'globals.css 缺少激活 tab 子节点高度承接规则');
+assertIncludes(cssSource, '.app-content {', 'globals.css 缺少 app-content 规则');
+assertIncludes(cssSource, '.app-main-grid {', 'globals.css 缺少 app-main-grid 规则');
+assertIncludes(cssSource, '.app-chat-panel {', 'globals.css 缺少 app-chat-panel 规则');
+assertIncludes(cssSource, '.app-session-panel {', 'globals.css 缺少 app-session-panel 规则');
+
+assertIncludes(devicePanelSource, 'minHeight: 0', 'DevicePanel 缺少 minHeight: 0，滚动容器会被内容撑开');
+
+console.log('layout scroll contract OK');


### PR DESCRIPTION
## 概要
- 修复左侧设备列表不能独立滚动的问题
- 避免设备栏把整体页面高度撑开
- 消除右侧聊天区域下方的多余空白

## 验证
- npm run test
- npx tsx src/test-layout-scroll.ts
- npx tsc --noEmit
- npm run lint
- npm run build