### PR TITLE
修复 Windows 下 MCP 构建失败

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "build:mcp": "tsc -p tsconfig.mcp.json && chmod 755 dist/mcp/mcp/index.js",
+    "build:mcp": "tsc -p tsconfig.mcp.json && node -e \"if(process.platform!=='win32')require('fs').chmodSync('dist/mcp/mcp/index.js',0o755)\"",
     "start": "next start",
     "lint": "next lint",
     "test": "npx tsx src/test.ts"


### PR DESCRIPTION
## 改动内容

- 将 `build:mcp` 中无条件执行的 `chmod` 改为 Node 平台判断。
- Windows 只执行 TypeScript 编译；非 Windows 继续通过 `chmodSync` 设置 MCP 入口文件的可执行位。

## 原因

上游脚本在 Windows 编译完成后会执行系统中不存在的 `chmod`，导致 `npm run build:mcp` 最终失败：

```text
'chmod' is not recognized as an internal or external command
```

## 影响

Windows 用户可以直接使用项目文档中的 `npm run build:mcp`。Unix 平台仍保留原有的 `755` 权限设置。

## 验证

- 修改前：Windows 上稳定复现 `chmod` 错误。
- 修改后：`npm run build:mcp` 通过。
- `npx tsc --noEmit` 通过。
- 当前环境未安装 WSL/Docker；非 Windows 分支沿用 Node 原生 `chmodSync`，未在本机进行 Linux 实测。
