### PR TITLE
新增原始网关 API 工具与设备事件参数解析

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build:mcp": "tsc -p tsconfig.mcp.json && chmod 755 dist/mcp/mcp/index.js",
     "start": "next start",
     "lint": "next lint",
-    "test": "npx tsx src/test.ts"
+    "test": "npx tsx src/test.ts",
+    "test:unit": "tsx --test tests/**/*.test.ts"
   },
   "bin": {
     "oh-my-sage-mcp": "./dist/mcp/mcp/index.js"

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -12,6 +12,7 @@ export type { GatewayManager } from './gateway/manager';
 export { getDevices, getDevice } from './tools/device';
 export { getGraphs, getGraph, createGraph, updateGraph, deleteGraph, toggleGraph } from './tools/graph';
 export { getVariables, setVariable } from './tools/variable';
+export { callGatewayApi, isReadOnlyGatewayMethod } from './tools/misc';
 export { validateGraph, layoutNodes } from './tools/base';
 
 // 类型

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -12,7 +12,7 @@ export type { GatewayManager } from './gateway/manager';
 export { getDevices, getDevice } from './tools/device';
 export { getGraphs, getGraph, createGraph, updateGraph, deleteGraph, toggleGraph } from './tools/graph';
 export { getVariables, setVariable } from './tools/variable';
-export { callGatewayApi, isReadOnlyGatewayMethod } from './tools/misc';
+export { callGatewayApi, READ_ONLY_GATEWAY_METHODS } from './tools/misc';
 export { validateGraph, layoutNodes } from './tools/base';
 
 // 类型

--- a/src/core/tools/device.ts
+++ b/src/core/tools/device.ts
@@ -51,7 +51,7 @@ export async function getDevice(gateway: GatewayClient, dids: string[]): Promise
                     const specUrl = `https://miot-spec.org/miot-spec-v2/instance?type=${encodeURIComponent(device.urn)}`;
                     const specRes = await fetch(specUrl);
                     if (specRes.ok) {
-                        const specData = await specRes.json() as { services?: Array<{ iid: number; description: string; properties?: Array<{ iid: number; description: string; format: string; access?: string[]; 'value-range'?: unknown; 'value-list'?: unknown }>; events?: Array<{ iid: number; description: string }>; actions?: Array<{ iid: number; description: string; in?: unknown[] }> }> };
+                        const specData = await specRes.json() as { services?: Array<{ iid: number; description: string; properties?: Array<{ iid: number; description: string; format: string; access?: string[]; 'value-range'?: unknown; 'value-list'?: unknown }>; events?: Array<{ iid: number; description: string; arguments?: number[] }>; actions?: Array<{ iid: number; description: string; in?: unknown[] }> }> };
                         const services = specData.services || [];
 
                         const triggers: DeviceInfo['triggers'] = [];
@@ -71,7 +71,24 @@ export async function getDevice(gateway: GatewayClient, dids: string[]): Promise
                                 if (p.access?.includes('read')) readable.push(cap);
                             }
                             for (const e of (s.events || [])) {
-                                triggers.push({ siid: s.iid, eiid: e.iid, desc: `${s.description}-${e.description}`, type: 'event' as const });
+                                const properties = s.properties || [];
+                                const args = (e.arguments || []).map((piid) => {
+                                    const property = properties.find((p) => p.iid === piid);
+                                    return {
+                                        piid,
+                                        desc: property?.description || `Property ${piid}`,
+                                        dtype: property?.format || 'unknown',
+                                        range: property?.['value-range'],
+                                        list: property?.['value-list'],
+                                    };
+                                });
+                                triggers.push({
+                                    siid: s.iid,
+                                    eiid: e.iid,
+                                    desc: `${s.description}-${e.description}`,
+                                    type: 'event' as const,
+                                    ...(args.length > 0 ? { arguments: args } : {}),
+                                });
                             }
                             for (const a of (s.actions || [])) {
                                 actions.push({ siid: s.iid, aiid: a.iid, desc: `${s.description}-${a.description}`, type: 'action' as const, in: a.in });

--- a/src/core/tools/misc.ts
+++ b/src/core/tools/misc.ts
@@ -6,6 +6,7 @@ import { GatewayClient } from '../gateway/client';
 import type { ToolResponse } from '../types';
 
 export const READ_ONLY_GATEWAY_METHODS = new Set([
+    'getApiList',
     'getBackupConfig',
     'getBackupList',
     'getBackupProgress',

--- a/src/core/tools/misc.ts
+++ b/src/core/tools/misc.ts
@@ -1,0 +1,32 @@
+/**
+ * Core - maintenance/debug tools.
+ */
+
+import { GatewayClient } from '../gateway/client';
+import type { ToolResponse } from '../types';
+
+export function isReadOnlyGatewayMethod(method: string): boolean {
+    return /^get[A-Z0-9_]/.test(method);
+}
+
+export async function callGatewayApi(
+    gateway: GatewayClient,
+    method: string,
+    params: Record<string, unknown> = {},
+    timeout: number = 10000,
+    allowMutation: boolean = false
+): Promise<ToolResponse<unknown>> {
+    if (!isReadOnlyGatewayMethod(method) && !allowMutation) {
+        return {
+            success: false,
+            error: `方法 ${method} 可能修改网关状态；如确需调用，请显式设置 allow_mutation=true`,
+        };
+    }
+
+    try {
+        const data = await gateway.callApi(method, params, timeout);
+        return { success: true, data };
+    } catch (error) {
+        return { success: false, error: `调用网关 API 失败: ${error}` };
+    }
+}

--- a/src/core/tools/misc.ts
+++ b/src/core/tools/misc.ts
@@ -5,21 +5,30 @@
 import { GatewayClient } from '../gateway/client';
 import type { ToolResponse } from '../types';
 
-export function isReadOnlyGatewayMethod(method: string): boolean {
-    return /^get[A-Z0-9_]/.test(method);
-}
+export const READ_ONLY_GATEWAY_METHODS = new Set([
+    'getBackupConfig',
+    'getBackupList',
+    'getBackupProgress',
+    'getDevList',
+    'getGraph',
+    'getGraphList',
+    'getLog',
+    'getVarConfig',
+    'getVarList',
+    'getVarScopeList',
+    'getVarValue',
+]);
 
 export async function callGatewayApi(
     gateway: GatewayClient,
     method: string,
     params: Record<string, unknown> = {},
-    timeout: number = 10000,
-    allowMutation: boolean = false
+    timeout: number = 10000
 ): Promise<ToolResponse<unknown>> {
-    if (!isReadOnlyGatewayMethod(method) && !allowMutation) {
+    if (!READ_ONLY_GATEWAY_METHODS.has(method)) {
         return {
             success: false,
-            error: `方法 ${method} 可能修改网关状态；如确需调用，请显式设置 allow_mutation=true`,
+            error: `方法 ${method} 不在已验证的只读 API 白名单中`,
         };
     }
 

--- a/src/core/types/device.ts
+++ b/src/core/types/device.ts
@@ -29,6 +29,13 @@ export interface DeviceInfo {
         type: 'prop' | 'event';
         range?: unknown;
         list?: unknown;
+        arguments?: Array<{
+            piid: number;
+            desc: string;
+            dtype: string;
+            range?: unknown;
+            list?: unknown;
+        }>;
     }>;
     actions?: Array<{
         siid: number;

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -12,6 +12,7 @@ import {
   registerAuthTools,
   registerDeviceTools,
   registerGraphTools,
+  registerMiscTools,
   registerVariableTools,
 } from "./tools/index.js";
 
@@ -34,6 +35,7 @@ function createServer(userConfig?: Config): McpServer {
   registerDeviceTools(server, gatewayManager);
   registerGraphTools(server, gatewayManager);
   registerVariableTools(server, gatewayManager);
+  registerMiscTools(server, gatewayManager);
 
   return server;
 }

--- a/src/mcp/tools/device.ts
+++ b/src/mcp/tools/device.ts
@@ -88,7 +88,7 @@ Error Handling:
       title: "获取设备详情",
       description: `获取指定设备的详细信息，包括 MIOT Spec 能力定义。
 
-返回设备的属性、触发事件、可执行动作等详细信息。
+返回设备的属性、触发事件（含事件参数和取值表）、可执行动作等详细信息。
 
 Args:
   - dids (string[]): 设备ID数组，支持批量查询
@@ -96,7 +96,7 @@ Args:
 
 Returns:
   - devices: 设备详情列表
-  - 包含 triggers(可触发能力), actions(可执行能力), readable(可读属性)
+  - 包含 triggers(可触发能力及事件 arguments), actions(可执行能力), readable(可读属性)
 
 Error Handling:
   - "网关未连接" - 请先调用 mijia_auth

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -6,3 +6,4 @@ export { registerAuthTools } from "./auth.js";
 export { registerDeviceTools } from "./device.js";
 export { registerGraphTools } from "./graph.js";
 export { registerVariableTools } from "./variable.js";
+export { registerMiscTools } from "./misc.js";

--- a/src/mcp/tools/misc.ts
+++ b/src/mcp/tools/misc.ts
@@ -1,0 +1,78 @@
+/**
+ * MCP Server - maintenance/debug tools.
+ */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { GatewayManager } from "../../core/gateway/manager.js";
+import { callGatewayApi } from "../../core/index.js";
+import { formatJson, handleError } from "../utils.js";
+
+export function registerMiscTools(
+  server: McpServer,
+  gatewayManager: GatewayManager
+): void {
+  server.registerTool(
+    "mijia_call_api",
+    {
+      title: "调用原始网关 API",
+      description: `维护/排障用：直接调用米家网关原始 API 方法。
+
+默认只允许 get* 读取方法。set*/create*/delete*/load* 等可能修改状态的方法，必须由用户明确授权并设置 allow_mutation=true。
+普通设备和自动化操作优先使用专用工具。
+
+只读示例：
+- getVarScopeList: {}
+- getVarList: {"scope":"global"}
+- getLog: {"num":0}
+- getBackupList: {"from":"fds"}
+
+Args:
+  - method: API 方法名
+  - params: 参数对象，默认 {}
+  - timeout: 超时时间毫秒，默认 10000
+  - allow_mutation: 是否允许可能修改网关状态的方法，默认 false`,
+      inputSchema: z.object({
+        method: z.string().min(1).describe("API 方法名"),
+        params: z.record(z.unknown()).default({}).describe("参数对象"),
+        timeout: z.number().int().positive().default(10000).describe("超时时间毫秒"),
+        allow_mutation: z.boolean().default(false).describe("显式允许可能修改状态的方法"),
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async ({ method, params = {}, timeout = 10000, allow_mutation = false }) => {
+      try {
+        gatewayManager.ensureConnected();
+        const result = await callGatewayApi(
+          gatewayManager.gateway!,
+          method,
+          params,
+          timeout,
+          allow_mutation
+        );
+
+        if (!result.success) {
+          return {
+            content: [{ type: "text", text: handleError(new Error(result.error), "call_api") }],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [{ type: "text", text: formatJson({ method, params, result: result.data }) }],
+          structuredContent: { method, params, result: result.data },
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: handleError(error, "call_api") }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/src/mcp/tools/misc.ts
+++ b/src/mcp/tools/misc.ts
@@ -18,7 +18,7 @@ export function registerMiscTools(
       title: "调用原始网关 API",
       description: `维护/排障用：直接调用米家网关原始 API 方法。
 
-默认只允许 get* 读取方法。set*/create*/delete*/load* 等可能修改状态的方法，必须由用户明确授权并设置 allow_mutation=true。
+只允许调用代码中明确列出的只读方法；写入、删除、恢复以及未知方法都会被拒绝。
 普通设备和自动化操作优先使用专用工具。
 
 只读示例：
@@ -30,30 +30,27 @@ export function registerMiscTools(
 Args:
   - method: API 方法名
   - params: 参数对象，默认 {}
-  - timeout: 超时时间毫秒，默认 10000
-  - allow_mutation: 是否允许可能修改网关状态的方法，默认 false`,
+  - timeout: 超时时间毫秒，默认 10000`,
       inputSchema: z.object({
         method: z.string().min(1).describe("API 方法名"),
         params: z.record(z.unknown()).default({}).describe("参数对象"),
         timeout: z.number().int().positive().default(10000).describe("超时时间毫秒"),
-        allow_mutation: z.boolean().default(false).describe("显式允许可能修改状态的方法"),
       }),
       annotations: {
-        readOnlyHint: false,
-        destructiveHint: true,
-        idempotentHint: false,
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
         openWorldHint: true,
       },
     },
-    async ({ method, params = {}, timeout = 10000, allow_mutation = false }) => {
+    async ({ method, params = {}, timeout = 10000 }) => {
       try {
         gatewayManager.ensureConnected();
         const result = await callGatewayApi(
           gatewayManager.gateway!,
           method,
           params,
-          timeout,
-          allow_mutation
+          timeout
         );
 
         if (!result.success) {

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -106,7 +106,14 @@ export function formatDeviceDetailsMarkdown(devices: Array<{
   modelName?: string;
   online?: boolean;
   roomName?: string;
-  triggers?: Array<{ desc: string; type: string }>;
+  triggers?: Array<{
+    desc: string;
+    type: string;
+    siid?: number;
+    piid?: number;
+    eiid?: number;
+    arguments?: Array<{ piid: number; desc: string; dtype: string; range?: unknown; list?: unknown }>;
+  }>;
   actions?: Array<{ desc: string; type: string }>;
 }>): string {
   const lines = ["## 设备详情", ""];
@@ -121,7 +128,11 @@ export function formatDeviceDetailsMarkdown(devices: Array<{
     if (device.triggers && device.triggers.length > 0) {
       lines.push("**可触发能力:**");
       for (const t of device.triggers) {
-        lines.push(`  - ${t.desc} (${t.type})`);
+        const ids = [t.siid && `siid=${t.siid}`, t.piid && `piid=${t.piid}`, t.eiid && `eiid=${t.eiid}`].filter(Boolean).join(", ");
+        lines.push(`  - ${t.desc} (${t.type}${ids ? `; ${ids}` : ""})`);
+        for (const arg of (t.arguments || [])) {
+          lines.push(`    - 参数 piid=${arg.piid}: ${arg.desc}, ${arg.dtype}${arg.list ? `, values=${JSON.stringify(arg.list)}` : ""}${arg.range ? `, range=${JSON.stringify(arg.range)}` : ""}`);
+        }
       }
       lines.push("");
     }

--- a/src/server/ai/tools-adapter.ts
+++ b/src/server/ai/tools-adapter.ts
@@ -7,7 +7,7 @@ import {z} from 'zod';
 import {tool} from 'ai';
 import {jsonSchema, type Schema, zodSchema} from '@ai-sdk/ui-utils';
 import {GatewayClient} from '@/core';
-import {getDevices, getDevice, getGraphs, getGraph, createGraph, updateGraph, deleteGraph, toggleGraph, getVariables, setVariable, validateGraph, layoutNodes} from '@/core';
+import {callGatewayApi, getDevices, getDevice, getGraphs, getGraph, createGraph, updateGraph, deleteGraph, toggleGraph, getVariables, setVariable, validateGraph, layoutNodes} from '@/core';
 import {getSkillByName, formatSkillContent, readSkillFile, getSkillCatalog} from '../skills/loader';
 
 function patchArrayItems(schema: unknown): unknown {
@@ -106,6 +106,18 @@ export function createCoreTools(gateway: GatewayClient) {
             }),
             execute: async ({dids}) => {
                 return getDevice(gateway, dids);
+            },
+        }),
+
+        call_gateway_api: defineTool({
+            description: '仅在用户明确要求排障、发现网关接口或查询未被专用工具覆盖的只读数据时使用。只能调用已验证的只读 API；写入、删除和未知方法会被拒绝。',
+            parameters: z.object({
+                method: z.string().describe('已验证的只读网关 API 方法名，例如 getApiList、getLog、getVarScopeList'),
+                params: z.record(z.unknown()).default({}).describe('API 参数对象'),
+                timeout: z.number().int().min(1000).max(10000).default(10000).describe('超时时间（毫秒）'),
+            }),
+            execute: async ({method, params, timeout}) => {
+                return callGatewayApi(gateway, method, params, timeout);
             },
         }),
 

--- a/tests/core/device.test.ts
+++ b/tests/core/device.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { GatewayClient } from '../../src/core/gateway/client';
+import { getDevice } from '../../src/core/tools/device';
+
+test('解析同一 service 的事件参数并为缺失属性提供 fallback', async () => {
+    const gateway = {
+        callApi: async () => ({
+            devList: {
+                dev1: {
+                    name: '测试双键',
+                    model: 'test.remote',
+                    modelName: '测试遥控器',
+                    online: true,
+                    roomName: '测试房间',
+                    urn: 'urn:test:remote',
+                },
+            },
+        }),
+    } as unknown as GatewayClient;
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response(JSON.stringify({
+        services: [{
+            iid: 3,
+            description: 'remote-control',
+            properties: [{
+                iid: 1,
+                description: 'button-id',
+                format: 'uint8',
+                'value-list': [{ value: 1, description: 'left' }, { value: 2, description: 'right' }],
+            }],
+            events: [{ iid: 1012, description: 'click', arguments: [1, 99] }],
+        }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+
+    try {
+        const result = await getDevice(gateway, ['dev1']);
+        assert.equal(result.success, true);
+        if (!result.success) return;
+
+        const event = result.data?.[0].triggers?.find((trigger) => trigger.type === 'event');
+        assert.deepEqual(event?.arguments?.[0], {
+            piid: 1,
+            desc: 'button-id',
+            dtype: 'uint8',
+            range: undefined,
+            list: [{ value: 1, description: 'left' }, { value: 2, description: 'right' }],
+        });
+        assert.deepEqual(event?.arguments?.[1], {
+            piid: 99,
+            desc: 'Property 99',
+            dtype: 'unknown',
+            range: undefined,
+            list: undefined,
+        });
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});

--- a/tests/core/misc.test.ts
+++ b/tests/core/misc.test.ts
@@ -19,7 +19,7 @@ test('只读 API 原样透传 method、params 和 timeout', async () => {
     });
 });
 
-test('未显式授权时拒绝写 API', async () => {
+test('拒绝写 API', async () => {
     let called = false;
     const gateway = gatewayWith(() => {
         called = true;
@@ -32,11 +32,11 @@ test('未显式授权时拒绝写 API', async () => {
     assert.equal(called, false);
 });
 
-test('显式授权后允许写 API', async () => {
+test('拒绝名称像读取方法但未进入白名单的 API', async () => {
     const gateway = gatewayWith((method) => method);
-    const result = await callGatewayApi(gateway, 'setGraph', {}, 10000, true);
+    const result = await callGatewayApi(gateway, 'getApiList');
 
-    assert.deepEqual(result, { success: true, data: 'setGraph' });
+    assert.equal(result.success, false);
 });
 
 test('网关异常转为失败响应', async () => {

--- a/tests/core/misc.test.ts
+++ b/tests/core/misc.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { GatewayClient } from '../../src/core/gateway/client';
+import { callGatewayApi } from '../../src/core/tools/misc';
+
+function gatewayWith(handler: (method: string, params: Record<string, unknown>, timeout: number) => unknown): GatewayClient {
+    return {
+        callApi: async (method: string, params: Record<string, unknown>, timeout: number) => handler(method, params, timeout),
+    } as unknown as GatewayClient;
+}
+
+test('只读 API 原样透传 method、params 和 timeout', async () => {
+    const gateway = gatewayWith((method, params, timeout) => ({ method, params, timeout }));
+    const result = await callGatewayApi(gateway, 'getLog', { num: 0 }, 3210);
+
+    assert.deepEqual(result, {
+        success: true,
+        data: { method: 'getLog', params: { num: 0 }, timeout: 3210 },
+    });
+});
+
+test('未显式授权时拒绝写 API', async () => {
+    let called = false;
+    const gateway = gatewayWith(() => {
+        called = true;
+        return undefined;
+    });
+
+    const result = await callGatewayApi(gateway, 'setGraph', {}, 10000);
+
+    assert.equal(result.success, false);
+    assert.equal(called, false);
+});
+
+test('显式授权后允许写 API', async () => {
+    const gateway = gatewayWith((method) => method);
+    const result = await callGatewayApi(gateway, 'setGraph', {}, 10000, true);
+
+    assert.deepEqual(result, { success: true, data: 'setGraph' });
+});
+
+test('网关异常转为失败响应', async () => {
+    const gateway = gatewayWith(() => {
+        throw new Error('boom');
+    });
+    const result = await callGatewayApi(gateway, 'getGraphList');
+
+    assert.equal(result.success, false);
+    if (!result.success) assert.match(result.error, /boom/);
+});

--- a/tests/core/misc.test.ts
+++ b/tests/core/misc.test.ts
@@ -32,11 +32,11 @@ test('拒绝写 API', async () => {
     assert.equal(called, false);
 });
 
-test('拒绝名称像读取方法但未进入白名单的 API', async () => {
+test('允许已验证的 API 列表读取接口', async () => {
     const gateway = gatewayWith((method) => method);
     const result = await callGatewayApi(gateway, 'getApiList');
 
-    assert.equal(result.success, false);
+    assert.deepEqual(result, {success: true, data: 'getApiList'});
 });
 
 test('网关异常转为失败响应', async () => {

--- a/tests/mcp/utils.test.ts
+++ b/tests/mcp/utils.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { formatDeviceDetailsMarkdown } from '../../src/mcp/utils';
+
+test('Markdown 展示事件 ID 和参数取值', () => {
+    const markdown = formatDeviceDetailsMarkdown([{
+        name: '测试双键',
+        did: 'dev1',
+        triggers: [{
+            desc: 'remote-control-click',
+            type: 'event',
+            siid: 3,
+            eiid: 1012,
+            arguments: [{
+                piid: 1,
+                desc: 'button-id',
+                dtype: 'uint8',
+                list: [{ value: 1, description: 'left' }],
+            }],
+        }],
+    }]);
+
+    assert.match(markdown, /siid=3, eiid=1012/);
+    assert.match(markdown, /参数 piid=1: button-id, uint8/);
+    assert.match(markdown, /left/);
+});

--- a/tests/server/web-raw-api.test.ts
+++ b/tests/server/web-raw-api.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { GatewayClient } from '../../src/core/gateway/client';
+import { createCoreTools } from '../../src/server/ai/tools-adapter';
+
+function gatewayWith(handler: (method: string, params: Record<string, unknown>, timeout: number) => unknown): GatewayClient {
+    return {
+        callApi: async (method: string, params: Record<string, unknown>, timeout: number) => handler(method, params, timeout),
+    } as unknown as GatewayClient;
+}
+
+test('Web Agent 可以调用白名单内的原始读取 API', async () => {
+    const gateway = gatewayWith((method, params, timeout) => ({method, params, timeout}));
+    const tools = createCoreTools(gateway) as any;
+
+    const result = await tools.call_gateway_api.execute({
+        method: 'getApiList',
+        params: {},
+        timeout: 3210,
+    });
+
+    assert.deepEqual(result, {
+        success: true,
+        data: {method: 'getApiList', params: {}, timeout: 3210},
+    });
+});
+
+test('Web Agent 无法绕过原始 API 的只读白名单', async () => {
+    let called = false;
+    const gateway = gatewayWith(() => {
+        called = true;
+        return undefined;
+    });
+    const tools = createCoreTools(gateway) as any;
+
+    const result = await tools.call_gateway_api.execute({
+        method: 'setGraph',
+        params: {},
+        timeout: 3210,
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(called, false);
+});


### PR DESCRIPTION
## 改动内容

这个 PR 增加两个互补能力：

1. 新增只读高级维护工具 `mijia_call_api`，可以调用中枢网关已验证的原始读取 API。
2. `mijia_get_device` 解析并展示 MIOT 事件参数，包括参数 PIID、类型、取值表和范围。

## 为什么需要

极客版网关还有不少未被专用 MCP 工具覆盖的读取 API，例如变量作用域、日志和云端备份。通用读取入口可以用于发现、排障和验证，不需要每发现一个接口就新增一套包装。

设备事件参数不在 `getDevList` 返回值中，而是在 MIOT Spec 的 event `arguments` 里。补充解析后，Agent 可以正确区分双键开关的左键、右键、双键等事件值。

## 安全边界

- 仅允许代码中明确列出的只读 API。
- 写入、删除、恢复和未知方法都会在调用网关前被拒绝。
- 不依赖 MCP annotation 或模型自行确认来保护写操作。

只读调用示例：

```json
{"method":"getVarScopeList","params":{}}
{"method":"getVarList","params":{"scope":"global"}}
{"method":"getLog","params":{"num":0}}
{"method":"getBackupList","params":{"from":"fds"}}
```

## 设备参数验证

使用真实 MIOT 双键设备验证，成功解析到：

- 点击事件：`siid=3, eiid=1012`
- 参数：`piid=1, dtype=uint8`
- 取值：左键、右键、左右同时按

PR 和测试中没有包含家庭名称、设备 DID 或网关地址。

## 验证

- `npm run test:unit`：6 项通过。
- `npx tsc -p tsconfig.mcp.json`：通过。
- `npx tsc --noEmit`：通过。
- `npm run build:mcp` 在当前独立分支仍会遇到上游已有的 Windows `chmod` 问题，对应修复见 #4。

## Web 端影响

Web Agent 现已提供 `call_gateway_api`：它复用 Core 的 `callGatewayApi` 与同一份严格只读白名单，可用于 `getApiList`、变量、日志、备份和规则等未被专用工具覆盖的读取/发现任务。

该工具是服务端工具，参数会原样传给 Core；写入、删除和未知方法仍会在调用网关前被拒绝，Web 端无法绕过此边界。

## Web 验证

新增适配层测试，覆盖 Web 调用 `getApiList` 的参数透传，以及 `setGraph` 被白名单拒绝。