### PR TITLE
修复图校验器对合法条件链的误拦截

### DIFF
--- a/.agents/skills/mijia-automation/SKILL.md
+++ b/.agents/skills/mijia-automation/SKILL.md
@@ -75,12 +75,12 @@ metadata:
 | **event 节点** | 可被触发 | 有 trigger/input 端口 | deviceOutput, condition, delay |
 | **state 节点** | 不能被触发 | `inputs: {}`（空） | timeRange, alarmClock, deviceInputSetVar |
 
-**⚠️ state 节点的 outputs 只能连到 event 节点的 condition 端口，不能作为触发链的一环。**
+**⚠️ state 条件节点通常连接 `condition.condition`，也可以先进入 `logicOr` / `logicAnd` / `logicNot`，再连接 `condition.condition`。state 节点没有输入端口，不能接收事件触发。**
 
 ### ⚠️ 网关不检查连接完整性（已验证）
 
 网关 `setGraph` **只校验节点级别结构**（字段类型、必填字段），**不校验连接级别的逻辑完整性**。以下错误都能通过网关校验但在运行时不工作：
-- condition 的 condition 端口未连接 → 通过校验，但条件永远满足
+- condition 的 condition 端口未连接 → 网关允许保存，但实测不会执行 met 分支
 - deviceGet.output2 连到 state 节点 → 通过校验，但语义错误
 
 **因此，生成规则后必须自行验证连接完整性**，不能依赖网关报错。
@@ -136,7 +136,7 @@ metadata:
 ```json
 {"id":"$ID","type":"timeRange","cfg":{"name":"timeRange","version":1},"props":{"start":{"hour":$SH,"minute":$SM,"second":0},"end":{"hour":$EH,"minute":$EM,"second":0},"filter":{"day":[0,1,2,3,4,5,6]}},"inputs":{},"outputs":{"output":["$NEXT.condition"]}}
 ```
-⚠️ state 节点，`inputs: {}`。`output` **只能连到 condition.condition**。多分支时 output 数组可包含多个目标（如 `["cond2.condition","cond3.condition"]`）。禁止任何节点的 output 连到 timeRange。禁止使用 output2。
+⚠️ state 节点，`inputs: {}`。`output` 可直接连到 `condition.condition`，也可连到 `logicOr.inputN` / `logicAnd.inputN` / `logicNot.input` 后再进入 `condition.condition`。多分支时 output 数组可包含多个目标。禁止任何节点的 output 连到 timeRange。禁止使用 output2。
 
 ### delay - 延时
 ```json
@@ -148,7 +148,7 @@ metadata:
 ```json
 {"id":"$ID","type":"condition","cfg":{"name":"condition","version":1},"props":{},"inputs":{"trigger":null,"condition":null},"outputs":{"met":["$NEXT1.trigger"],"unmet":["$NEXT2.trigger"]}}
 ```
-⚠️ **`trigger` 和 `condition` 必须都有信号来源**，缺一不可。`trigger` = "当"（event 节点触发），`condition` = "如果"（state 节点提供条件值）。如果 `condition` 未连接 → 网关默认为 true，条件永远满足。如果 `trigger` 未连接 → 节点永远不会被触发。生成规则后必须遍历 outputs 数组确认两者都有来源。
+⚠️ **`trigger` 和 `condition` 必须都有信号来源**，缺一不可。`trigger` = "当"（event 节点触发），`condition` = "如果"（state/logic 节点提供条件值）。`condition` 未连接时网关虽允许保存，但实测不会执行 met 分支；`trigger` 未连接时节点不会被触发。
 
 ### signalOr - 任一事件
 ```json
@@ -158,18 +158,18 @@ metadata:
 
 ### logicOr - 满足任一条件
 ```json
-{"id":"$ID","type":"logicOr","cfg":{"name":"logicOr","version":1},"props":{},"inputs":{"input0":null,"input1":null},"outputs":{"output":["$NEXT.trigger"]}}
+{"id":"$ID","type":"logicOr","cfg":{"name":"logicOr","version":1},"props":{},"inputs":{"input0":null,"input1":null},"outputs":{"output":["$NEXT.condition"]}}
 ```
 ⚠️ inputs 值可以是 `boolean | null`（状态条件）。
 
 ### logicAnd - 满足全部条件
 ```json
-{"id":"$ID","type":"logicAnd","cfg":{"name":"logicAnd","version":1},"props":{},"inputs":{"input0":null,"input1":null},"outputs":{"output":["$NEXT.trigger"]}}
+{"id":"$ID","type":"logicAnd","cfg":{"name":"logicAnd","version":1},"props":{},"inputs":{"input0":null,"input1":null},"outputs":{"output":["$NEXT.condition"]}}
 ```
 
 ### logicNot - 状态取反
 ```json
-{"id":"$ID","type":"logicNot","cfg":{"name":"logicNot","version":1},"props":{},"inputs":{"input":null},"outputs":{"output":["$NEXT.trigger"]}}
+{"id":"$ID","type":"logicNot","cfg":{"name":"logicNot","version":1},"props":{},"inputs":{"input":null},"outputs":{"output":["$NEXT.condition"]}}
 ```
 
 ### loop - 循环

--- a/docs/validator-compatibility-evidence.md
+++ b/docs/validator-compatibility-evidence.md
@@ -1,0 +1,60 @@
+# 图校验兼容性验证
+
+验证日期：2026-07-15。测试通过中枢网关原始 API 创建临时变量和临时规则；所有规则均使用通用变量节点，不包含家庭、设备或网络信息。测试完成后按前缀扫描，确认临时规则和变量均已删除。
+
+## 结论
+
+| 用例 | 网关保存/回读 | 延后触发后的目标值 | 校验器结论 |
+|---|---|---:|---|
+| `timeRange → logicOr → condition.condition` | 成功 | `1` | 有效，应允许 |
+| `timeRange → logicAnd → condition.condition` | 成功 | `1` | 有效，应允许 |
+| `timeRange → logicNot → condition.condition` | 成功 | unmet 分支写入 `1` | 有效，应允许 |
+| `condition.condition` 无来源 | 成功 | `0` | 无运行效果，保持 error |
+| `varGet.output2 → timeRange.trigger` | 成功 | `0` | state 不消费事件，保持 error |
+| `varGet.output2 → varSetNumber.input` | 成功 | `1` | event 输入有效，作为对照 |
+
+## 最小复现方法
+
+每个运行用例都在规则启动完成后执行以下步骤，避免把 state 节点初始化输出误认为 incoming 事件的效果：
+
+1. 将目标变量重置为 `0`。
+2. 修改独立触发变量，使 `varChange` 发出事件。
+3. 等待规则执行后读取目标变量。
+
+### 合法条件组合
+
+```text
+varChange.output → condition.trigger
+timeRange.output → logicOr.input0/input1
+logicOr.output → condition.condition
+condition.met → varSetNumber.input
+```
+
+目标变量由 `0` 变为 `1`，证明 `timeRange` 经过逻辑节点提供条件值具有实际运行语义。
+
+同样的延后触发方法也验证了 `logicAnd`：两个全天时间段同时为真时 met 分支写入 `1`。`logicNot` 使用全天为真的时间段，取反后由 unmet 分支写入 `1`。因此三种逻辑节点均有运行证据。
+
+### 缺失 condition 来源
+
+```text
+varChange.output → condition.trigger
+condition.condition ← 无来源
+condition.met → varSetNumber.input
+```
+
+网关接受并完整回读规则，但延后触发后目标变量保持 `0`，因此不能仅凭“可保存”放宽校验。
+
+### output2 到 state 与 event 的对照
+
+```text
+# 无效
+varChange.output → varGet.input
+varGet.output2 → timeRange.trigger
+timeRange.output → varSetNumber.input
+
+# 有效对照
+varChange.output → varGet.input
+varGet.output2 → varSetNumber.input
+```
+
+两个规则均能保存和回读。启动后重置目标变量并触发：state 目标保持 `0`，event 目标变为 `1`。这说明网关不校验连接语义，但 `output2 → state` 没有可观察的运行效果，应继续作为 error。

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build:mcp": "tsc -p tsconfig.mcp.json && chmod 755 dist/mcp/mcp/index.js",
     "start": "next start",
     "lint": "next lint",
-    "test": "npx tsx src/test.ts"
+    "test": "npx tsx src/test.ts",
+    "test:unit": "tsx --test tests/**/*.test.ts"
   },
   "bin": {
     "oh-my-sage-mcp": "./dist/mcp/mcp/index.js"

--- a/src/core/tools/base.ts
+++ b/src/core/tools/base.ts
@@ -11,6 +11,51 @@ const STATE_NODE_TYPES = new Set([
 
 const DUAL_OUTPUT_TYPES = new Set(['deviceGet', 'varGet', 'deviceGetSetVar']);
 
+const STATE_CONDITION_INPUT_TYPES = new Set(['condition', 'logicOr', 'logicAnd', 'logicNot']);
+
+function targetInfo(target: string): { id: string; port: string } | null {
+    const dotIdx = target.lastIndexOf('.');
+    if (dotIdx === -1) return null;
+    return { id: target.substring(0, dotIdx), port: target.substring(dotIdx + 1) };
+}
+
+function isDeclaredConditionInput(node: GraphNode, port: string): boolean {
+    if (!Object.prototype.hasOwnProperty.call(node.inputs || {}, port)) return false;
+    if (node.type === 'condition') return port === 'condition';
+    if (node.type === 'logicNot') return port === 'input';
+    return (node.type === 'logicOr' || node.type === 'logicAnd') && /^input\d+$/.test(port);
+}
+
+function reachesConditionInput(nodeId: string, nodeMap: Map<string, GraphNode>, visited: Set<string>): boolean {
+    if (visited.has(nodeId)) return false;
+    visited.add(nodeId);
+
+    const node = nodeMap.get(nodeId);
+    if (!node) return false;
+
+    for (const target of node.outputs?.output || []) {
+        const info = targetInfo(target);
+        if (!info) continue;
+        const targetNode = nodeMap.get(info.id);
+        if (!targetNode || !isDeclaredConditionInput(targetNode, info.port)) continue;
+        if (targetNode.type === 'condition') return true;
+        if (reachesConditionInput(targetNode.id, nodeMap, new Set(visited))) return true;
+    }
+
+    return false;
+}
+
+function canAcceptStateCondition(target: string, nodeMap: Map<string, GraphNode>): boolean {
+    const info = targetInfo(target);
+    if (!info) return false;
+
+    const targetNode = nodeMap.get(info.id);
+    if (!targetNode || !STATE_CONDITION_INPUT_TYPES.has(targetNode.type)) return false;
+    if (!isDeclaredConditionInput(targetNode, info.port)) return false;
+
+    return targetNode.type === 'condition' || reachesConditionInput(targetNode.id, nodeMap, new Set());
+}
+
 export function validateGraph(graph: Graph): ValidationError[] {
     const errors: ValidationError[] = [];
     const nodeMap = new Map<string, GraphNode>();
@@ -113,9 +158,8 @@ export function validateGraph(graph: Graph): ValidationError[] {
                 errors.push({ nodeId: node.id, type: 'tr_has_output2', level: 'error', message: 'timeRange 只有 output，没有 output2' });
             }
             for (const t of node.outputs?.output || []) {
-                const port = t.substring(t.lastIndexOf('.') + 1);
-                if (port !== 'condition') {
-                    errors.push({ nodeId: node.id, type: 'tr_wrong_target', level: 'error', message: `timeRange.output 只能连 condition.condition，当前连到 "${t}"` });
+                if (!canAcceptStateCondition(t, nodeMap)) {
+                    errors.push({ nodeId: node.id, type: 'tr_wrong_target', level: 'error', message: `timeRange.output 只能连 condition.condition 或 logicOr/logicAnd/logicNot 的条件输入，当前连到 "${t}"` });
                 }
             }
         }

--- a/src/mcp/tools/graph.ts
+++ b/src/mcp/tools/graph.ts
@@ -388,7 +388,7 @@ Args:
 - deviceGet 必须有 output 和 output2
 - condition 必须有 trigger 和 condition 两个输入源
 - delay 节点的 inputs 必须用 "input" 而非 "trigger"
-- timeRange 只能连到 condition.condition
+- timeRange 可连接 condition.condition，或经 logicOr/logicAnd/logicNot 最终连接 condition.condition
 - 所有节点的 props、inputs、outputs 必须存在
 
 Args:

--- a/tests/core/base.test.ts
+++ b/tests/core/base.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { Graph, GraphNode } from '../../src/core/types/graph';
+import { validateGraph } from '../../src/core/tools/base';
+
+function node(
+    id: string,
+    type: string,
+    inputs: Record<string, unknown>,
+    outputs: Record<string, string[]>,
+    props: Record<string, unknown> = {}
+): GraphNode {
+    return { id, type, cfg: { name: type, version: 1 }, props, inputs, outputs };
+}
+
+function graph(nodes: GraphNode[]): Graph {
+    return {
+        id: 'testgraph',
+        nodes,
+        cfg: {
+            id: 'testgraph',
+            enable: false,
+            uiType: 'graph',
+            userData: {
+                name: 'validator test',
+                lastUpdateTime: 0,
+                transform: { x: 0, y: 0, scale: 1, rotate: 0 },
+            },
+        },
+    };
+}
+
+function conditionGraph(logic: GraphNode, targetPort: string): Graph {
+    return graph([
+        node('load', 'onLoad', {}, { output: ['cond.trigger'] }),
+        node('range', 'timeRange', {}, { output: [`logic.${targetPort}`] }),
+        logic,
+        node('cond', 'condition', { trigger: null, condition: null }, { met: [], unmet: [] }),
+    ]);
+}
+
+test('timeRange 可以连接 logicOr、logicAnd 和 logicNot 的条件输入', () => {
+    const cases = [
+        conditionGraph(node('logic', 'logicOr', { input0: null }, { output: ['cond.condition'] }), 'input0'),
+        conditionGraph(node('logic', 'logicAnd', { input0: null, input1: null }, { output: ['cond.condition'] }), 'input1'),
+        conditionGraph(node('logic', 'logicNot', { input: null }, { output: ['cond.condition'] }), 'input'),
+    ];
+
+    for (const value of cases) {
+        assert.equal(validateGraph(value).some((error) => error.type === 'tr_wrong_target'), false);
+    }
+});
+
+test('timeRange 连接事件端口仍然报错', () => {
+    const value = graph([
+        node('range', 'timeRange', {}, { output: ['cond.trigger'] }),
+        node('cond', 'condition', { trigger: null, condition: null }, { met: [], unmet: [] }),
+    ]);
+
+    assert.equal(validateGraph(value).some((error) => error.type === 'tr_wrong_target' && error.level === 'error'), true);
+});
+
+test('timeRange 连接未声明的 logic 端口仍然报错', () => {
+    const value = conditionGraph(
+        node('logic', 'logicOr', { input0: null }, { output: ['cond.condition'] }),
+        'input999'
+    );
+
+    assert.equal(validateGraph(value).some((error) => error.type === 'tr_wrong_target' && error.level === 'error'), true);
+});
+
+test('logic 条件链未到达 condition.condition 时仍然报错', () => {
+    const value = graph([
+        node('range', 'timeRange', {}, { output: ['logic.input0'] }),
+        node('logic', 'logicOr', { input0: null }, { output: ['set.input'] }),
+        node('set', 'varSetNumber', { input: null }, { output: [] }),
+    ]);
+
+    assert.equal(validateGraph(value).some((error) => error.type === 'tr_wrong_target' && error.level === 'error'), true);
+});
+
+test('condition 缺少 condition 来源仍然报错', () => {
+    const value = graph([
+        node('load', 'onLoad', {}, { output: ['cond.trigger'] }),
+        node('cond', 'condition', { trigger: null, condition: null }, { met: [], unmet: [] }),
+    ]);
+
+    assert.equal(validateGraph(value).some((error) => error.type === 'cond_no_condition' && error.level === 'error'), true);
+});
+
+test('output2 连接 state 节点仍然报错，连接 event 输入不报该错误', () => {
+    const invalid = graph([
+        node('get', 'varGet', { input: null }, { output: [], output2: ['range.trigger'] }),
+        node('range', 'timeRange', {}, { output: [] }),
+    ]);
+    const valid = graph([
+        node('get', 'varGet', { input: null }, { output: [], output2: ['set.input'] }),
+        node('set', 'varSetNumber', { input: null }, { output: [] }),
+    ]);
+
+    assert.equal(validateGraph(invalid).some((error) => error.type === 'output2_to_state' && error.level === 'error'), true);
+    assert.equal(validateGraph(valid).some((error) => error.type === 'output2_to_state'), false);
+});

--- a/tests/server/web-validator.test.ts
+++ b/tests/server/web-validator.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { GatewayClient } from '../../src/core/gateway/client';
+import { createCoreTools } from '../../src/server/ai/tools-adapter';
+
+const cfg = {
+    id: 'web-validator-test',
+    enable: false,
+    uiType: 'graph',
+    userData: {
+        name: 'web validator test',
+        lastUpdateTime: 0,
+        transform: {x: 0, y: 0, scale: 1, rotate: 0},
+    },
+};
+
+function node(
+    id: string,
+    type: string,
+    inputs: Record<string, unknown>,
+    outputs: Record<string, string[]>
+) {
+    return {id, type, cfg: {name: type, version: 1}, props: {}, inputs, outputs};
+}
+
+test('Web validate_graph 接受已验证的 timeRange 条件链', async () => {
+    const tools = createCoreTools({} as GatewayClient) as any;
+    const result = await tools.validate_graph.execute({
+        cfg,
+        nodes: [
+            node('load', 'onLoad', {}, {output: ['cond.trigger']}),
+            node('range', 'timeRange', {}, {output: ['logic.input0']}),
+            node('logic', 'logicOr', {input0: null}, {output: ['cond.condition']}),
+            node('cond', 'condition', {trigger: null, condition: null}, {met: [], unmet: []}),
+        ],
+    });
+
+    assert.deepEqual(result, {success: true, valid: true, message: '规则校验通过'});
+});
+
+test('Web validate_graph 仍拒绝 output2 连接状态节点', async () => {
+    const tools = createCoreTools({} as GatewayClient) as any;
+    const result = await tools.validate_graph.execute({
+        cfg,
+        nodes: [
+            node('get', 'varGet', {input: null}, {output: [], output2: ['range.trigger']}),
+            node('range', 'timeRange', {}, {output: []}),
+        ],
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.valid, false);
+    assert.equal(result.errors.some((error: {type: string}) => error.type === 'output2_to_state'), true);
+});


### PR DESCRIPTION
## 背景

现有校验器只允许 `timeRange.output` 直接连接 `condition.condition`，会误拦截米家极客版实际可运行的状态条件组合。

## 修改

- 允许 `timeRange` 经 `logicOr`、`logicAnd` 或 `logicNot` 最终连接 `condition.condition`
- 要求目标端口必须真实声明，且逻辑链最终确实到达 `condition.condition`
- 保持对事件端口、虚构逻辑端口和无效逻辑死路的拦截
- 保持 `condition.condition` 无来源为错误
- 保持 `deviceGet/varGet/deviceGetSetVar.output2 → state node` 为错误
- 补充最小复现证据、单元测试和 skill 文档

## 网关运行证据

使用临时变量和临时规则，在规则启动后重置目标值并延后触发，避免把初始化输出误判为运行效果：

| 用例 | 结果 |
|---|---|
| `timeRange → logicOr → condition.condition` | met 分支写入成功 |
| `timeRange → logicAnd → condition.condition` | met 分支写入成功 |
| `timeRange → logicNot → condition.condition` | unmet 分支写入成功 |
| `condition.condition` 无来源 | 可保存，但延后触发后无运行效果 |
| `varGet.output2 → timeRange.trigger` | 可保存，但延后触发后无运行效果 |
| `varGet.output2 → varSetNumber.input` | 对照组写入成功 |

因此本 PR 只放宽已有运行证据的状态条件链；`output2 → state node` 不应放宽。所有临时规则和变量均已清理。

## 验证

- `npm run test:unit`：6/6 通过
- `npx tsc -p tsconfig.mcp.json`：通过
- `npx tsc --noEmit`：通过
- `git diff --check`：通过

Windows 下完整 `npm run build:mcp` 仍受原脚本 `chmod` 问题影响，对应独立 PR #4。

## Web 端影响

`validateGraph` 位于共享 Core，Web 端的 `validate_graph` 同样使用本 PR 的兼容性规则。

## Web 验证

新增 Web 适配层回归测试：`timeRange → logicOr → condition.condition` 通过校验；`output2 → state` 仍被拒绝。放宽范围严格限定为已验证的条件链。