### PR TITLE
完善 MIOT 设备能力校验，避免错误规则导致极客版网页崩溃

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -11,7 +11,7 @@ export type { GatewayManager } from './gateway/manager';
 // 工具函数
 export { getDevices, getDevice } from './tools/device';
 export { getGraphs, getGraph, createGraph, updateGraph, deleteGraph, toggleGraph } from './tools/graph';
-export { getVariables, setVariable, createVariable, deleteVariable, getVariableConfig, getVariableValue } from './tools/variable';
+export { getVariables, setVariable } from './tools/variable';
 export { callGatewayApi, READ_ONLY_GATEWAY_METHODS } from './tools/misc';
 export { validateGraphCapabilitiesWithGateway } from './tools/capabilityValidation';
 export { validateGraph, layoutNodes } from './tools/base';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -11,11 +11,21 @@ export type { GatewayManager } from './gateway/manager';
 // 工具函数
 export { getDevices, getDevice } from './tools/device';
 export { getGraphs, getGraph, createGraph, updateGraph, deleteGraph, toggleGraph } from './tools/graph';
-export { getVariables, setVariable } from './tools/variable';
+export { getVariables, setVariable, createVariable, deleteVariable, getVariableConfig, getVariableValue } from './tools/variable';
 export { callGatewayApi, READ_ONLY_GATEWAY_METHODS } from './tools/misc';
+export { validateGraphCapabilitiesWithGateway } from './tools/capabilityValidation';
 export { validateGraph, layoutNodes } from './tools/base';
 
 // 类型
-export type { Device, DeviceInfo, DeviceListResponse } from './types/device';
+export type {
+    Device,
+    DeviceInfo,
+    DeviceListResponse,
+    MiotActionCapability,
+    MiotEventCapability,
+    MiotPropertyCapability,
+    MiotValueListItem,
+    MiotValueRange,
+} from './types/device';
 export type { Graph, GraphNode, GraphConfig, GraphSummary, CreateGraphInput, ValidationError } from './types/graph';
 export type { ToolResult, ToolError, ToolResponse, Variable } from './types';

--- a/src/core/tools/capabilityValidation.test.ts
+++ b/src/core/tools/capabilityValidation.test.ts
@@ -5,6 +5,7 @@ const device = {
   urn: 'urn:test:motion',
   properties: [{ siid: 2, piid: 2, desc: 'No Motion Duration', dtype: 'uint16', access: ['read', 'notify'], unit: 'minutes', list: [{ value: 2, description: '2 Minutes' }, { value: 5, description: '5 Minutes' }] }],
   events: [],
+  actions: [],
 };
 const base = { id: 'n1', type: 'deviceGet', cfg: { urn: 'urn:test:motion' }, inputs: { input: null }, outputs: { output: [], output2: [] } };
 const invalid = validateGraphCapabilities([{ ...base, props: { did: 'sensor', siid: 2, piid: 2, dtype: 'int', operator: '>=', v1: 50 } }], new Map([['sensor', device]]));
@@ -12,4 +13,29 @@ assert.equal(invalid.valid, false);
 assert.match(invalid.errors[0].message, /枚举字段/);
 const valid = validateGraphCapabilities([{ ...base, props: { did: 'sensor', siid: 2, piid: 2, dtype: 'int', operator: 'include', v1: [2] } }], new Map([['sensor', device]]));
 assert.equal(valid.valid, true);
+const speaker = {
+  urn: 'urn:test:speaker',
+  properties: [],
+  events: [],
+  actions: [{ siid: 7, aiid: 3, desc: 'Play Text', in: [{ siid: 7, piid: 1, desc: 'Text Content', dtype: 'string', access: [] }] }],
+};
+const playText = { id: 'tts', type: 'deviceOutput', cfg: { urn: 'urn:test:speaker' }, props: { did: 'speaker', siid: 7, aiid: 3, ins: [{ piid: 1, value: 'Close the fridge door.' }] }, inputs: { trigger: null }, outputs: { output: [] } };
+assert.equal(validateGraphCapabilities([playText], new Map([['speaker', speaker]])).valid, true);
+assert.equal(validateGraphCapabilities([{ ...playText, props: { ...playText.props, aiid: 99 } }], new Map([['speaker', speaker]])).valid, false);
+assert.equal(validateGraphCapabilities([{ ...playText, props: { ...playText.props, ins: [{ piid: 1, value: 123 }] } }], new Map([['speaker', speaker]])).valid, false);
+
+// Action input with enum/range params: single scalar values are valid (must NOT require operator=include)
+const lamp = {
+  urn: 'urn:test:lamp',
+  properties: [],
+  events: [],
+  actions: [{ siid: 3, aiid: 15, desc: 'Apply Scene', in: [{ siid: 3, piid: 9, desc: 'Scene', dtype: 'uint8', access: [], list: [{ value: 5, description: 'Reading' }, { value: 6, description: 'Working' }] }] }, { siid: 3, aiid: 2, desc: 'Delay Off', in: [{ siid: 3, piid: 2, desc: 'Minutes', dtype: 'uint8', access: [], range: { min: 1, max: 60, step: 1 } }] }],
+};
+const lampMap = new Map([['lamp', lamp]]);
+const scene = { id: 's', type: 'deviceOutput', cfg: { urn: 'urn:test:lamp' }, props: { did: 'lamp', siid: 3, aiid: 15, ins: [{ piid: 9, value: 5 }] }, inputs: { trigger: null }, outputs: { output: [] } };
+assert.equal(validateGraphCapabilities([scene], lampMap).valid, true);
+assert.equal(validateGraphCapabilities([{ ...scene, props: { ...scene.props, ins: [{ piid: 9, value: 99 }] } }], lampMap).valid, false);
+const delay = { id: 'd', type: 'deviceOutput', cfg: { urn: 'urn:test:lamp' }, props: { did: 'lamp', siid: 3, aiid: 2, ins: [{ piid: 2, value: 10 }] }, inputs: { trigger: null }, outputs: { output: [] } };
+assert.equal(validateGraphCapabilities([delay], lampMap).valid, true);
+assert.equal(validateGraphCapabilities([{ ...delay, props: { ...delay.props, ins: [{ piid: 2, value: 999 }] } }], lampMap).valid, false);
 console.log('capability validation tests passed');

--- a/src/core/tools/capabilityValidation.test.ts
+++ b/src/core/tools/capabilityValidation.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { validateGraphCapabilities } from './capabilityValidation.js';
+
+const device = {
+  urn: 'urn:test:motion',
+  properties: [{ siid: 2, piid: 2, desc: 'No Motion Duration', dtype: 'uint16', access: ['read', 'notify'], unit: 'minutes', list: [{ value: 2, description: '2 Minutes' }, { value: 5, description: '5 Minutes' }] }],
+  events: [],
+};
+const base = { id: 'n1', type: 'deviceGet', cfg: { urn: 'urn:test:motion' }, inputs: { input: null }, outputs: { output: [], output2: [] } };
+const invalid = validateGraphCapabilities([{ ...base, props: { did: 'sensor', siid: 2, piid: 2, dtype: 'int', operator: '>=', v1: 50 } }], new Map([['sensor', device]]));
+assert.equal(invalid.valid, false);
+assert.match(invalid.errors[0].message, /枚举字段/);
+const valid = validateGraphCapabilities([{ ...base, props: { did: 'sensor', siid: 2, piid: 2, dtype: 'int', operator: 'include', v1: [2] } }], new Map([['sensor', device]]));
+assert.equal(valid.valid, true);
+console.log('capability validation tests passed');

--- a/src/core/tools/capabilityValidation.ts
+++ b/src/core/tools/capabilityValidation.ts
@@ -1,5 +1,5 @@
 import { GatewayClient } from '../gateway/client';
-import type { DeviceListResponse, MiotEventCapability, MiotPropertyCapability } from '../types/device';
+import type { DeviceListResponse, MiotActionCapability, MiotEventCapability, MiotPropertyCapability } from '../types/device';
 import type { Graph, GraphNode, ValidationError } from '../types/graph';
 import { normalizeMiotSpec } from './device';
 
@@ -7,6 +7,7 @@ export interface DeviceCapabilities {
     urn: string;
     properties: MiotPropertyCapability[];
     events: MiotEventCapability[];
+    actions: MiotActionCapability[];
 }
 
 export interface CapabilityValidationReport {
@@ -60,6 +61,42 @@ function validateValue(node: GraphNode, property: MiotPropertyCapability, operat
     return errors;
 }
 
+function validateActionInputValue(node: GraphNode, property: MiotPropertyCapability, value: unknown): ValidationError[] {
+    if (!validScalar(value, property.dtype)) return [error(node, 'action_input_type', `${property.desc} 需要 ${property.dtype} 类型值`)];
+    if (property.list && !property.list.some((item) => item.value === value)) {
+        return [error(node, 'action_input_enum', `${property.desc} 不支持值 ${JSON.stringify(value)}；允许值 ${JSON.stringify(property.list.map((item) => item.value))}`)];
+    }
+    if (property.range && typeof value === 'number' && (value < property.range.min || value > property.range.max || ((value - property.range.min) % property.range.step !== 0))) {
+        return [error(node, 'action_input_range', `${property.desc} 值 ${value} 超出范围 ${JSON.stringify(property.range)}`)];
+    }
+    return [];
+}
+
+function validateAction(node: GraphNode, device: DeviceCapabilities): ValidationError[] {
+    const siid = node.props.siid;
+    const aiid = node.props.aiid;
+    if (typeof siid !== 'number' || typeof aiid !== 'number') return [error(node, 'missing_action', '动作节点缺少 siid 或 aiid')];
+    const action = device.actions.find((item) => item.siid === siid && item.aiid === aiid);
+    if (!action) return [error(node, 'unknown_action', `找不到动作 siid=${siid}, aiid=${aiid}`)];
+    const inputs = node.props.ins;
+    if (!Array.isArray(inputs)) return action.in.length ? [error(node, 'missing_action_input', `${action.desc} 需要输入参数`)] : [];
+
+    const errors: ValidationError[] = [];
+    for (const input of inputs) {
+        if (!input || typeof input !== 'object') { errors.push(error(node, 'invalid_action_input', `${action.desc} 的输入参数格式错误`)); continue; }
+        const entry = input as Record<string, unknown>;
+        const property = typeof entry.piid === 'number' ? action.in.find((item) => item.piid === entry.piid) : undefined;
+        if (!property) { errors.push(error(node, 'unknown_action_input', `${action.desc} 不支持输入 piid=${String(entry.piid)}`)); continue; }
+        errors.push(...validateActionInputValue(node, property, entry.value));
+    }
+    for (const property of action.in) {
+        if (!inputs.some((input) => input && typeof input === 'object' && (input as Record<string, unknown>).piid === property.piid)) {
+            errors.push(error(node, 'missing_action_input', `${action.desc} 缺少输入 ${property.desc}`));
+        }
+    }
+    return errors;
+}
+
 export function validateGraphCapabilities(nodes: GraphNode[], devices: Map<string, DeviceCapabilities>): CapabilityValidationReport {
     const errors: ValidationError[] = [];
     const warnings: ValidationError[] = [];
@@ -75,6 +112,10 @@ export function validateGraphCapabilities(nodes: GraphNode[], devices: Map<strin
         if (node.type === 'deviceInput' && typeof props.eiid === 'number') {
             const event = device.events.find((item) => item.siid === siid && item.eiid === props.eiid);
             if (!event) errors.push(error(node, 'unknown_event', `找不到事件 siid=${siid}, eiid=${String(props.eiid)}`));
+            continue;
+        }
+        if (node.type === 'deviceOutput' && typeof props.aiid === 'number') {
+            errors.push(...validateAction(node, device));
             continue;
         }
         const piid = props.piid;
@@ -103,7 +144,7 @@ export async function validateGraphCapabilitiesWithGateway(gateway: GatewayClien
                 const result = await fetch(`https://miot-spec.org/miot-spec-v2/instance?type=${encodeURIComponent(device.urn)}`);
                 if (!result.ok) throw new Error(`HTTP ${result.status}`);
                 const normalized = normalizeMiotSpec(await result.json() as { services?: Array<never> });
-                specs.set(device.urn, { urn: device.urn, properties: normalized.properties || [], events: normalized.events || [] });
+                specs.set(device.urn, { urn: device.urn, properties: normalized.properties || [], events: normalized.events || [], actions: (normalized.actions || []).flatMap((action) => action.type === 'action' && typeof action.aiid === 'number' ? [{ siid: action.siid, aiid: action.aiid, desc: action.desc, in: action.in || [] }] : []) });
             } catch (cause) {
                 errors.push({ nodeId: '(graph)', type: 'spec_unavailable', level: 'error', message: `无法读取 ${device.urn} 的 MIOT Spec: ${String(cause)}` });
             }

--- a/src/core/tools/capabilityValidation.ts
+++ b/src/core/tools/capabilityValidation.ts
@@ -1,0 +1,121 @@
+import { GatewayClient } from '../gateway/client';
+import type { DeviceListResponse, MiotEventCapability, MiotPropertyCapability } from '../types/device';
+import type { Graph, GraphNode, ValidationError } from '../types/graph';
+import { normalizeMiotSpec } from './device';
+
+export interface DeviceCapabilities {
+    urn: string;
+    properties: MiotPropertyCapability[];
+    events: MiotEventCapability[];
+}
+
+export interface CapabilityValidationReport {
+    valid: boolean;
+    errors: ValidationError[];
+    warnings: ValidationError[];
+    inspectedDids: string[];
+    inspectedUrns: string[];
+}
+
+function error(node: GraphNode, type: string, message: string): ValidationError {
+    return { nodeId: node.id, type, level: 'error', message };
+}
+
+function graphDtypeMatches(miot: string, graph: unknown, setVar: boolean): boolean {
+    if (setVar && graph === 'number') return /^(u?int\d*|float)$/.test(miot);
+    if (/^u?int\d*$/.test(miot)) return graph === 'int';
+    if (miot === 'bool') return graph === 'boolean';
+    return graph === miot;
+}
+
+function validScalar(value: unknown, dtype: string): boolean {
+    if (dtype === 'string') return typeof value === 'string';
+    if (dtype === 'bool') return typeof value === 'boolean';
+    if (typeof value !== 'number' || !Number.isFinite(value)) return false;
+    return !/^u?int\d*$/.test(dtype) || Number.isInteger(value);
+}
+
+function validateValue(node: GraphNode, property: MiotPropertyCapability, operator: unknown, v1: unknown, v2?: unknown): ValidationError[] {
+    const errors: ValidationError[] = [];
+    if (property.list) {
+        if (operator !== 'include' || !Array.isArray(v1)) {
+            return [error(node, 'enum_filter', `${property.desc} 是枚举字段，必须使用 operator="include" 和数组 v1；允许值 ${JSON.stringify(property.list.map((item) => item.value))}`)];
+        }
+        for (const value of v1) {
+            if (!validScalar(value, property.dtype) || !property.list.some((item) => item.value === value)) {
+                errors.push(error(node, 'enum_value', `${property.desc} 不支持值 ${JSON.stringify(value)}；允许值 ${JSON.stringify(property.list.map((item) => item.value))}`));
+            }
+        }
+        return errors;
+    }
+    if (property.range) {
+        const values = operator === 'between' ? [v1, v2] : [v1];
+        if (operator === 'between' && v2 === undefined) errors.push(error(node, 'range_between', `${property.desc} 使用 between 时必须提供 v2`));
+        for (const value of values) {
+            if (!validScalar(value, property.dtype)) errors.push(error(node, 'value_type', `${property.desc} 需要 ${property.dtype} 类型值`));
+            else if (typeof value === 'number' && (value < property.range.min || value > property.range.max || ((value - property.range.min) % property.range.step !== 0))) errors.push(error(node, 'range_value', `${property.desc} 值 ${value} 超出范围 ${JSON.stringify(property.range)}`));
+        }
+        if (typeof v1 === 'number' && typeof v2 === 'number' && v1 > v2) errors.push(error(node, 'range_order', `${property.desc} 的 v1 不能大于 v2`));
+    }
+    return errors;
+}
+
+export function validateGraphCapabilities(nodes: GraphNode[], devices: Map<string, DeviceCapabilities>): CapabilityValidationReport {
+    const errors: ValidationError[] = [];
+    const warnings: ValidationError[] = [];
+    for (const node of nodes) {
+        if (!['deviceInput', 'deviceGet', 'deviceOutput', 'deviceInputSetVar', 'deviceGetSetVar'].includes(node.type)) continue;
+        const props = node.props;
+        const did = props.did;
+        if (typeof did !== 'string' || !devices.has(did)) { errors.push(error(node, 'unknown_device', `找不到设备 ${String(did)}`)); continue; }
+        const device = devices.get(did)!;
+        if (node.cfg.urn !== device.urn) { errors.push(error(node, 'urn_mismatch', `节点 URN 与设备 ${did} 的 URN 不一致`)); continue; }
+        const siid = props.siid;
+        if (typeof siid !== 'number') { errors.push(error(node, 'missing_siid', '缺少 siid')); continue; }
+        if (node.type === 'deviceInput' && typeof props.eiid === 'number') {
+            const event = device.events.find((item) => item.siid === siid && item.eiid === props.eiid);
+            if (!event) errors.push(error(node, 'unknown_event', `找不到事件 siid=${siid}, eiid=${String(props.eiid)}`));
+            continue;
+        }
+        const piid = props.piid;
+        const property = typeof piid === 'number' ? device.properties.find((item) => item.siid === siid && item.piid === piid) : undefined;
+        if (!property) { errors.push(error(node, 'unknown_property', `找不到属性 siid=${siid}, piid=${String(piid)}`)); continue; }
+        const requiredAccess = node.type === 'deviceInput' || node.type === 'deviceInputSetVar' ? 'notify' : node.type === 'deviceGet' || node.type === 'deviceGetSetVar' ? 'read' : 'write';
+        if (!property.access.includes(requiredAccess)) errors.push(error(node, 'access_denied', `${property.desc} 不支持 ${requiredAccess}`));
+        const setVar = node.type === 'deviceInputSetVar' || node.type === 'deviceGetSetVar';
+        if (props.dtype !== undefined && !graphDtypeMatches(property.dtype, props.dtype, setVar)) errors.push(error(node, 'dtype_mismatch', `${property.desc} 的 MIOT 类型为 ${property.dtype}，节点类型应兼容 ${setVar ? 'number' : property.dtype}`));
+        if (node.type === 'deviceOutput') errors.push(...validateValue(node, property, '=', props.value));
+        else if (!setVar) errors.push(...validateValue(node, property, props.operator, props.v1, props.v2));
+    }
+    return { valid: errors.length === 0, errors, warnings, inspectedDids: [...devices.keys()], inspectedUrns: [...new Set([...devices.values()].map((device) => device.urn))] };
+}
+
+export async function validateGraphCapabilitiesWithGateway(gateway: GatewayClient, graph: Graph): Promise<CapabilityValidationReport> {
+    const response = await gateway.callApi<DeviceListResponse>('getDevList', {}, 10000);
+    const dids = [...new Set(graph.nodes.map((node) => node.props.did).filter((did): did is string => typeof did === 'string'))];
+    const specs = new Map<string, DeviceCapabilities>();
+    const errors: ValidationError[] = [];
+    for (const did of dids) {
+        const device = response.devList?.[did];
+        if (!device?.urn) { errors.push({ nodeId: '(graph)', type: 'unknown_device', level: 'error', message: `设备 ${did} 缺少本地 URN` }); continue; }
+        if (!specs.has(device.urn)) {
+            try {
+                const result = await fetch(`https://miot-spec.org/miot-spec-v2/instance?type=${encodeURIComponent(device.urn)}`);
+                if (!result.ok) throw new Error(`HTTP ${result.status}`);
+                const normalized = normalizeMiotSpec(await result.json() as { services?: Array<never> });
+                specs.set(device.urn, { urn: device.urn, properties: normalized.properties || [], events: normalized.events || [] });
+            } catch (cause) {
+                errors.push({ nodeId: '(graph)', type: 'spec_unavailable', level: 'error', message: `无法读取 ${device.urn} 的 MIOT Spec: ${String(cause)}` });
+            }
+        }
+    }
+    const devices = new Map<string, DeviceCapabilities>();
+    for (const did of dids) {
+        const device = response.devList?.[did];
+        if (device?.urn && specs.has(device.urn)) devices.set(did, specs.get(device.urn)!);
+    }
+    const report = validateGraphCapabilities(graph.nodes, devices);
+    report.errors.unshift(...errors);
+    report.valid = report.errors.length === 0;
+    return report;
+}

--- a/src/core/tools/device.test.ts
+++ b/src/core/tools/device.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { normalizeMiotSpec } from './device.js';
+
+const normalized = normalizeMiotSpec({
+  services: [{
+    iid: 2,
+    description: 'Motion Sensor',
+    properties: [{
+      iid: 2,
+      description: 'No Motion Duration',
+      format: 'uint16',
+      unit: 'minutes',
+      access: ['read', 'notify'],
+      'value-list': [
+        { value: 2, description: '2 Minutes' },
+        { value: 5, description: '5 Minutes' },
+      ],
+    }, {
+      iid: 3,
+      description: 'Brightness',
+      format: 'uint8',
+      access: ['read', 'write', 'notify'],
+      'value-range': [1, 100, 1],
+    }],
+    events: [{ iid: 1, description: 'Motion Detected', arguments: [2] }],
+    actions: [{ iid: 1, description: 'Set Brightness', in: [3] }],
+  }],
+});
+
+assert.equal(normalized.properties?.[0]?.unit, 'minutes');
+assert.deepEqual(normalized.properties?.[0]?.list, [
+  { value: 2, description: '2 Minutes' },
+  { value: 5, description: '5 Minutes' },
+]);
+assert.deepEqual(normalized.properties?.[1]?.range, { min: 1, max: 100, step: 1 });
+assert.deepEqual(normalized.events?.[0]?.arguments[0]?.list, normalized.properties?.[0]?.list);
+const action = normalized.actions?.find((candidate) => candidate.type === 'action');
+assert.equal(action?.in?.[0]?.piid, 3);
+assert.deepEqual(action?.in?.[0]?.range, { min: 1, max: 100, step: 1 });
+assert.throws(() => normalizeMiotSpec({ services: [] }), /does not contain services/);
+
+console.log('device capability normalization tests passed');

--- a/src/core/tools/device.ts
+++ b/src/core/tools/device.ts
@@ -3,8 +3,158 @@
  */
 
 import { GatewayClient } from '../gateway/client';
-import type { Device, DeviceInfo, DeviceListResponse } from '../types/device';
-import type { ToolResponse, ToolResult } from '../types';
+import type {
+    Device,
+    DeviceInfo,
+    DeviceListResponse,
+    MiotActionCapability,
+    MiotEventCapability,
+    MiotPropertyCapability,
+    MiotValueListItem,
+    MiotValueRange,
+} from '../types/device';
+import type { ToolResponse } from '../types';
+
+interface MiotSpecProperty {
+    iid: number;
+    description: string;
+    format: string;
+    unit?: string;
+    access?: string[];
+    'value-range'?: unknown;
+    'value-list'?: unknown;
+}
+
+interface MiotSpecService {
+    iid: number;
+    description: string;
+    properties?: MiotSpecProperty[];
+    events?: Array<{ iid: number; description: string; arguments?: number[] }>;
+    actions?: Array<{ iid: number; description: string; in?: number[] }>;
+}
+
+interface MiotSpec {
+    services?: MiotSpecService[];
+}
+
+function normalizeRange(value: unknown): MiotValueRange | undefined {
+    if (!Array.isArray(value) || value.length !== 3 || !value.every((item) => typeof item === 'number' && Number.isFinite(item))) {
+        return undefined;
+    }
+    return { min: value[0], max: value[1], step: value[2] };
+}
+
+function normalizeList(value: unknown): MiotValueListItem[] | undefined {
+    if (!Array.isArray(value) || !value.every((item) => {
+        if (!item || typeof item !== 'object') return false;
+        const entry = item as Record<string, unknown>;
+        return (typeof entry.value === 'string' || typeof entry.value === 'number' || typeof entry.value === 'boolean') && typeof entry.description === 'string';
+    })) {
+        return undefined;
+    }
+    return value.map((item) => {
+        const entry = item as { value: string | number | boolean; description: string };
+        return { value: entry.value, description: entry.description };
+    });
+}
+
+function propertyCapability(siid: number, serviceDescription: string, property: MiotSpecProperty): MiotPropertyCapability {
+    return {
+        siid,
+        piid: property.iid,
+        desc: `${serviceDescription}-${property.description}`,
+        dtype: property.format,
+        access: property.access || [],
+        ...(property.unit ? { unit: property.unit } : {}),
+        ...(normalizeRange(property['value-range']) ? { range: normalizeRange(property['value-range']) } : {}),
+        ...(normalizeList(property['value-list']) ? { list: normalizeList(property['value-list']) } : {}),
+    };
+}
+
+export function normalizeMiotSpec(spec: MiotSpec): Pick<DeviceInfo, 'properties' | 'events' | 'triggers' | 'actions' | 'readable'> {
+    if (!Array.isArray(spec.services) || spec.services.length === 0) {
+        throw new Error('MIOT Spec does not contain services');
+    }
+
+    const properties: MiotPropertyCapability[] = [];
+    const events: MiotEventCapability[] = [];
+    const actionCapabilities: MiotActionCapability[] = [];
+    const triggers: NonNullable<DeviceInfo['triggers']> = [];
+    const actions: NonNullable<DeviceInfo['actions']> = [];
+    const readable: NonNullable<DeviceInfo['readable']> = [];
+
+    for (const service of spec.services) {
+        const serviceProperties = (service.properties || []).map((property) => propertyCapability(service.iid, service.description, property));
+        properties.push(...serviceProperties);
+
+        for (const property of serviceProperties) {
+            const legacy = {
+                siid: property.siid,
+                piid: property.piid,
+                desc: property.desc,
+                dtype: property.dtype,
+                range: property.range,
+                list: property.list,
+            };
+            if (property.access.includes('notify')) triggers.push({ ...legacy, type: 'prop' });
+            if (property.access.includes('write')) actions.push({ ...legacy, type: 'prop' });
+            if (property.access.includes('read')) readable.push({ ...legacy, unit: property.unit });
+        }
+
+        for (const event of service.events || []) {
+            const argumentsList = (event.arguments || []).map((piid) => {
+                const property = serviceProperties.find((candidate) => candidate.piid === piid);
+                return property || {
+                    siid: service.iid,
+                    piid,
+                    desc: `Property ${piid}`,
+                    dtype: 'unknown',
+                    access: [],
+                };
+            });
+            const capability: MiotEventCapability = {
+                siid: service.iid,
+                eiid: event.iid,
+                desc: `${service.description}-${event.description}`,
+                arguments: argumentsList,
+            };
+            events.push(capability);
+            triggers.push({
+                siid: capability.siid,
+                eiid: capability.eiid,
+                desc: capability.desc,
+                type: 'event',
+                ...(capability.arguments.length > 0 ? { arguments: capability.arguments } : {}),
+            });
+        }
+
+        for (const action of service.actions || []) {
+            const inputs = (action.in || []).map((piid) => serviceProperties.find((property) => property.piid === piid) || {
+                siid: service.iid,
+                piid,
+                desc: `Property ${piid}`,
+                dtype: 'unknown',
+                access: [],
+            });
+            const capability: MiotActionCapability = {
+                siid: service.iid,
+                aiid: action.iid,
+                desc: `${service.description}-${action.description}`,
+                in: inputs,
+            };
+            actionCapabilities.push(capability);
+            actions.push({
+                siid: capability.siid,
+                aiid: capability.aiid,
+                desc: capability.desc,
+                type: 'action',
+                in: capability.in,
+            });
+        }
+    }
+
+    return { properties, events, triggers, actions, readable };
+}
 
 export async function getDevices(gateway: GatewayClient): Promise<ToolResponse<Device[]>> {
     try {
@@ -51,53 +201,7 @@ export async function getDevice(gateway: GatewayClient, dids: string[]): Promise
                     const specUrl = `https://miot-spec.org/miot-spec-v2/instance?type=${encodeURIComponent(device.urn)}`;
                     const specRes = await fetch(specUrl);
                     if (specRes.ok) {
-                        const specData = await specRes.json() as { services?: Array<{ iid: number; description: string; properties?: Array<{ iid: number; description: string; format: string; access?: string[]; 'value-range'?: unknown; 'value-list'?: unknown }>; events?: Array<{ iid: number; description: string; arguments?: number[] }>; actions?: Array<{ iid: number; description: string; in?: unknown[] }> }> };
-                        const services = specData.services || [];
-
-                        const triggers: DeviceInfo['triggers'] = [];
-                        const actions: DeviceInfo['actions'] = [];
-                        const readable: DeviceInfo['readable'] = [];
-
-                        for (const s of services) {
-                            for (const p of (s.properties || [])) {
-                                const cap = {
-                                    siid: s.iid,
-                                    piid: p.iid,
-                                    desc: `${s.description}-${p.description}`,
-                                    dtype: p.format,
-                                };
-                                if (p.access?.includes('notify')) triggers.push({ ...cap, type: 'prop' as const });
-                                if (p.access?.includes('write')) actions.push({ ...cap, type: 'prop' as const, range: p['value-range'], list: p['value-list'] });
-                                if (p.access?.includes('read')) readable.push(cap);
-                            }
-                            for (const e of (s.events || [])) {
-                                const properties = s.properties || [];
-                                const args = (e.arguments || []).map((piid) => {
-                                    const property = properties.find((p) => p.iid === piid);
-                                    return {
-                                        piid,
-                                        desc: property?.description || `Property ${piid}`,
-                                        dtype: property?.format || 'unknown',
-                                        range: property?.['value-range'],
-                                        list: property?.['value-list'],
-                                    };
-                                });
-                                triggers.push({
-                                    siid: s.iid,
-                                    eiid: e.iid,
-                                    desc: `${s.description}-${e.description}`,
-                                    type: 'event' as const,
-                                    ...(args.length > 0 ? { arguments: args } : {}),
-                                });
-                            }
-                            for (const a of (s.actions || [])) {
-                                actions.push({ siid: s.iid, aiid: a.iid, desc: `${s.description}-${a.description}`, type: 'action' as const, in: a.in });
-                            }
-                        }
-
-                        info.triggers = triggers;
-                        info.actions = actions;
-                        info.readable = readable;
+                        Object.assign(info, normalizeMiotSpec(await specRes.json() as MiotSpec));
                     } else {
                         info.specError = `HTTP ${specRes.status}`;
                     }

--- a/src/core/types/device.ts
+++ b/src/core/types/device.ts
@@ -11,6 +11,44 @@ export interface Device {
     roomName: string;
 }
 
+export interface MiotValueRange {
+    min: number;
+    max: number;
+    step: number;
+}
+
+export interface MiotValueListItem {
+    value: string | number | boolean;
+    description: string;
+}
+
+export interface MiotPropertyCapability {
+    siid: number;
+    piid: number;
+    desc: string;
+    dtype: string;
+    access: string[];
+    unit?: string;
+    range?: MiotValueRange;
+    list?: MiotValueListItem[];
+}
+
+export interface MiotEventArgumentCapability extends MiotPropertyCapability {}
+
+export interface MiotEventCapability {
+    siid: number;
+    eiid: number;
+    desc: string;
+    arguments: MiotEventArgumentCapability[];
+}
+
+export interface MiotActionCapability {
+    siid: number;
+    aiid: number;
+    desc: string;
+    in: MiotPropertyCapability[];
+}
+
 /** 设备详情信息 */
 export interface DeviceInfo {
     did: string;
@@ -20,6 +58,8 @@ export interface DeviceInfo {
     online: boolean;
     roomName: string;
     urn: string;
+    properties?: MiotPropertyCapability[];
+    events?: MiotEventCapability[];
     triggers?: Array<{
         siid: number;
         piid?: number;
@@ -46,13 +86,16 @@ export interface DeviceInfo {
         type: 'prop' | 'action';
         range?: unknown;
         list?: unknown;
-        in?: unknown[];
+        in?: MiotPropertyCapability[];
     }>;
     readable?: Array<{
         siid: number;
         piid: number;
         desc: string;
         dtype?: string;
+        unit?: string;
+        range?: MiotValueRange;
+        list?: MiotValueListItem[];
     }>;
     specError?: string;
 }

--- a/src/mcp/tools/device.ts
+++ b/src/mcp/tools/device.ts
@@ -88,7 +88,7 @@ Error Handling:
       title: "获取设备详情",
       description: `获取指定设备的详细信息，包括 MIOT Spec 能力定义。
 
-返回设备的属性、触发事件（含事件参数和取值表）、可执行动作等详细信息。
+返回完整 MIOT Spec 能力：所有属性的读写订阅权限、类型、单位、枚举取值、数值范围，以及事件参数和动作输入参数。排查设备映射时优先使用本工具，无需先读取日志。
 
 Args:
   - dids (string[]): 设备ID数组，支持批量查询
@@ -96,7 +96,7 @@ Args:
 
 Returns:
   - devices: 设备详情列表
-  - 包含 triggers(可触发能力及事件 arguments), actions(可执行能力), readable(可读属性)
+  - 包含 properties(所有字段约束), events(事件及参数), triggers, actions(含输入参数), readable
 
 Error Handling:
   - "网关未连接" - 请先调用 mijia_auth

--- a/src/mcp/tools/graph.ts
+++ b/src/mcp/tools/graph.ts
@@ -13,6 +13,7 @@ import {
   deleteGraph,
   toggleGraph,
   validateGraph,
+  validateGraphCapabilitiesWithGateway,
 } from "../../core/index.js";
 import {
   ResponseFormatSchema,
@@ -25,6 +26,27 @@ export function registerGraphTools(
   server: McpServer,
   gatewayManager: GatewayManager
 ): void {
+  server.registerTool(
+    "mijia_validate_graph_capabilities",
+    {
+      title: "校验规则设备能力",
+      description: "根据真实 MIOT Spec 校验规则的 DID、URN、字段权限、类型、枚举值和数值范围。创建或更新设备节点前必须先通过本校验和 mijia_validate_graph。",
+      inputSchema: z.object({
+        graph: z.object({ id: z.string(), nodes: z.array(z.any()), cfg: z.any() }).describe("完整规则对象"),
+      }),
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    },
+    async ({ graph }) => {
+      try {
+        gatewayManager.ensureConnected();
+        const report = await validateGraphCapabilitiesWithGateway(gatewayManager.gateway!, graph as Parameters<typeof validateGraphCapabilitiesWithGateway>[1]);
+        return { content: [{ type: "text", text: formatJson(report) }], structuredContent: { ...report }, isError: !report.valid };
+      } catch (error) {
+        return { content: [{ type: "text", text: handleError(error, "validate_graph_capabilities") }], isError: true };
+      }
+    }
+  );
+
   // ==================== mijia_get_graphs ====================
   server.registerTool(
     "mijia_get_graphs",

--- a/src/mcp/utils.test.ts
+++ b/src/mcp/utils.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { formatDeviceDetailsMarkdown } from './utils.js';
+
+const output = formatDeviceDetailsMarkdown([{
+  did: 'sensor-1',
+  name: 'Motion Sensor',
+  properties: [{
+    siid: 2, piid: 2, desc: 'Motion Sensor-No Motion Duration', dtype: 'uint16',
+    access: ['read', 'notify'], unit: 'minutes', list: [{ value: 2, description: '2 Minutes' }],
+  }],
+  events: [{ siid: 2, eiid: 1, desc: 'Motion Sensor-Motion Detected', arguments: [] }],
+  actions: [{
+    siid: 2, aiid: 1, desc: 'Light-Set Brightness', type: 'action',
+    in: [{ siid: 2, piid: 3, desc: 'Light-Brightness', dtype: 'uint8', access: ['write'], range: { min: 1, max: 100, step: 1 } }],
+  }],
+}]);
+
+assert.match(output, /unit=minutes/);
+assert.match(output, /values=\[{"value":2,"description":"2 Minutes"}\]/);
+assert.match(output, /range=\{"min":1,"max":100,"step":1\}/);
+assert.match(output, /参数 piid=3: Light-Brightness/);
+console.log('device Markdown formatting tests passed');

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from "zod";
+import type { MiotActionCapability, MiotEventCapability, MiotPropertyCapability } from "../core/types/device.js";
 
 // 响应格式枚举
 export const ResponseFormatSchema = z.enum(["markdown", "json"]);
@@ -106,6 +107,8 @@ export function formatDeviceDetailsMarkdown(devices: Array<{
   modelName?: string;
   online?: boolean;
   roomName?: string;
+  properties?: MiotPropertyCapability[];
+  events?: MiotEventCapability[];
   triggers?: Array<{
     desc: string;
     type: string;
@@ -114,7 +117,7 @@ export function formatDeviceDetailsMarkdown(devices: Array<{
     eiid?: number;
     arguments?: Array<{ piid: number; desc: string; dtype: string; range?: unknown; list?: unknown }>;
   }>;
-  actions?: Array<{ desc: string; type: string }>;
+  actions?: Array<{ desc: string; type: string; siid?: number; piid?: number; aiid?: number; in?: MiotActionCapability["in"] }>;
 }>): string {
   const lines = ["## 设备详情", ""];
 
@@ -124,6 +127,40 @@ export function formatDeviceDetailsMarkdown(devices: Array<{
     lines.push(`- 状态: ${device.online ? "在线 ✅" : "离线 ❌"}`);
     lines.push(`- 房间: ${device.roomName || "未分组"}`);
     lines.push("");
+
+    if (device.properties && device.properties.length > 0) {
+      lines.push("**属性能力（所有字段）:**");
+      for (const property of device.properties) {
+        const details = [
+          `siid=${property.siid}`,
+          `piid=${property.piid}`,
+          `dtype=${property.dtype}`,
+          `access=${property.access.join(",") || "none"}`,
+          property.unit && `unit=${property.unit}`,
+          property.list && `values=${JSON.stringify(property.list)}`,
+          property.range && `range=${JSON.stringify(property.range)}`,
+        ].filter(Boolean).join(", ");
+        lines.push(`  - ${property.desc} (${details})`);
+      }
+      lines.push("");
+    }
+
+    if (device.events && device.events.length > 0) {
+      lines.push("**事件能力:**");
+      for (const event of device.events) {
+        lines.push(`  - ${event.desc} (siid=${event.siid}, eiid=${event.eiid})`);
+        for (const arg of event.arguments) {
+          const details = [
+            `dtype=${arg.dtype}`,
+            arg.unit && `unit=${arg.unit}`,
+            arg.list && `values=${JSON.stringify(arg.list)}`,
+            arg.range && `range=${JSON.stringify(arg.range)}`,
+          ].filter(Boolean).join(", ");
+          lines.push(`    - 参数 piid=${arg.piid}: ${arg.desc} (${details})`);
+        }
+      }
+      lines.push("");
+    }
 
     if (device.triggers && device.triggers.length > 0) {
       lines.push("**可触发能力:**");
@@ -140,7 +177,17 @@ export function formatDeviceDetailsMarkdown(devices: Array<{
     if (device.actions && device.actions.length > 0) {
       lines.push("**可执行动作:**");
       for (const a of device.actions) {
-        lines.push(`  - ${a.desc} (${a.type})`);
+        const ids = [a.siid && `siid=${a.siid}`, a.piid && `piid=${a.piid}`, a.aiid && `aiid=${a.aiid}`].filter(Boolean).join(", ");
+        lines.push(`  - ${a.desc} (${a.type}${ids ? `; ${ids}` : ""})`);
+        for (const input of a.in || []) {
+          const details = [
+            `dtype=${input.dtype}`,
+            input.unit && `unit=${input.unit}`,
+            input.list && `values=${JSON.stringify(input.list)}`,
+            input.range && `range=${JSON.stringify(input.range)}`,
+          ].filter(Boolean).join(", ");
+          lines.push(`    - 参数 piid=${input.piid}: ${input.desc} (${details})`);
+        }
       }
       lines.push("");
     }


### PR DESCRIPTION
Closes #7

## 变更内容

- `mijia_get_device` 现在返回完整 MIOT 属性能力：读写订阅权限、单位、枚举值和数值范围。
- 事件参数和动作输入参数会解析为完整属性约束。
- 新增 `mijia_validate_graph_capabilities`，在写规则前校验 DID、URN、权限、字段类型、枚举值和数值范围。
- 新增设备能力解析、Markdown 输出和能力预检回归测试。

## 修复的问题

`lumi.motion.bmgl01` 的“无人持续时间”类型为 `uint16`，但实际是单位为分钟的枚举字段，只接受 `[2, 5]`。错误使用 `>= 50` 时网关会保存规则，但极客版网页渲染会抛出 `r.includes is not a function`。

新预检会在写入前拒绝此类规则，并明确返回允许值。

## 验证

- `npx tsx src/core/tools/device.test.ts`
- `npx tsx src/mcp/utils.test.ts`
- `npx tsx src/core/tools/capabilityValidation.test.ts`
- `npx tsc --noEmit`
- `npm run build:mcp`
- 已在真实网关上只读验证：历史错误字段 `>= 50` 被正确拒绝，未写入任何规则。