### PR TITLE
fix: 移除网关地址硬编码默认值，缺省时提示用户提供 (#9)

### DIFF
--- a/src/core/gateway/manager.ts
+++ b/src/core/gateway/manager.ts
@@ -26,7 +26,10 @@ export function createGatewayManager(): GatewayManager {
         },
 
         async connect(passcode: string, gatewayUrl?: string): Promise<void> {
-            const url = gatewayUrl || process.env.GATEWAY_URL || 'http://192.168.0.5';
+            const url = gatewayUrl || process.env.GATEWAY_URL;
+            if (!url) {
+                throw new Error('未配置网关地址：请在 mijia_auth 的 gateway_url 参数中提供网关地址，或在 MCP 配置里设置 GATEWAY_URL 环境变量');
+            }
 
             if (gateway) {
                 try {

--- a/src/mcp/config.test.ts
+++ b/src/mcp/config.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { getConfig } from './config.js';
+
+// 无 gateway_url 参数、无环境变量时，getConfig 返回空字符串（不再回退到硬编码 IP）
+const saved = process.env.GATEWAY_URL;
+delete process.env.GATEWAY_URL;
+assert.equal(getConfig().gatewayUrl, '', '缺省时不应返回硬编码默认地址');
+assert.equal(getConfig({ gatewayUrl: 'http://10.0.0.1' }).gatewayUrl, 'http://10.0.0.1', '应优先使用传入参数');
+process.env.GATEWAY_URL = 'http://10.0.0.2';
+assert.equal(getConfig().gatewayUrl, 'http://10.0.0.2', '应使用环境变量');
+if (saved === undefined) delete process.env.GATEWAY_URL; else process.env.GATEWAY_URL = saved;
+
+console.log('config gateway url tests passed');

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -5,8 +5,9 @@
 import { z } from "zod";
 
 // 默认配置
+// 注意：不为 GATEWAY_URL 设置硬编码默认地址。每个家庭的网关地址都不同，
+// 静默回退到某个固定 IP 会导致连接错误的设备并超时。缺省时应提示用户提供地址。
 export const DEFAULT_CONFIG = {
-  GATEWAY_URL: "http://192.168.0.5",
   CONNECT_TIMEOUT: 10000,
   API_TIMEOUT: 5000,
 } as const;
@@ -22,13 +23,13 @@ export type Config = z.infer<typeof ConfigSchema>;
 
 /**
  * 获取配置值
- * 优先级：传入参数 > 环境变量 > 默认值
+ * 优先级：传入参数 > 环境变量 > 空（缺省时由调用方提示用户提供地址）
  */
 export function getConfig(userConfig?: Config): Required<Config> {
   const config = ConfigSchema.parse(userConfig || {});
 
   return {
-    gatewayUrl: config.gatewayUrl || process.env.GATEWAY_URL || DEFAULT_CONFIG.GATEWAY_URL,
+    gatewayUrl: config.gatewayUrl || process.env.GATEWAY_URL || "",
     connectTimeout: config.connectTimeout || DEFAULT_CONFIG.CONNECT_TIMEOUT,
     apiTimeout: config.apiTimeout || DEFAULT_CONFIG.API_TIMEOUT,
   };

--- a/src/mcp/tools/auth.ts
+++ b/src/mcp/tools/auth.ts
@@ -25,7 +25,7 @@ export function registerAuthTools(
 
 Args:
   - passcode (string): 6位数字登录码，从网关设备上获取
-  - gateway_url (string, optional): 网关地址，默认 ${config.gatewayUrl}
+  - gateway_url (string, optional): 网关地址。未提供时使用 MCP 配置的 GATEWAY_URL 环境变量；两者都没有时会返回错误，请提供地址
 
 Returns:
   - success: boolean - 连接是否成功
@@ -33,11 +33,12 @@ Returns:
 
 Error Handling:
   - "登录码格式错误" - passcode 不是6位数字
+  - "未配置网关地址" - 未提供 gateway_url 且未设置 GATEWAY_URL，请提供网关地址
   - "网关连接失败" - 无法连接到网关地址
   - "认证失败" - 登录码不正确`,
       inputSchema: z.object({
         passcode: z.string().regex(/^\d{6}$/, "必须是6位数字").describe("6位数字登录码"),
-        gateway_url: z.string().url().optional().describe(`可选，默认 ${config.gatewayUrl}`),
+        gateway_url: z.string().url().optional().describe("网关地址，可选；缺省时使用 GATEWAY_URL 环境变量，两者都无则报错"),
       }),
       annotations: {
         readOnlyHint: false,
@@ -55,6 +56,12 @@ Error Handling:
       }
       try {
         const url = gateway_url || config.gatewayUrl;
+        if (!url) {
+          return {
+            content: [{ type: "text", text: JSON.stringify({ success: false, error: "未配置网关地址：请在 gateway_url 参数中提供网关地址，或在 MCP 配置里设置 GATEWAY_URL 环境变量" }) }],
+            isError: true,
+          };
+        }
         await gatewayManager.connect(passcode, url);
         return {
           content: [{ type: "text", text: JSON.stringify({ success: true, message: "连接成功", gateway_url: url }) }],


### PR DESCRIPTION
## 背景

修复 #9。

在新的 MCP session 中，如果进程没有拿到 `GATEWAY_URL` 环境变量（例如通过 npm 全局 shim 启动、或客户端未透传 env），`mijia_auth` 会静默回退到硬编码的默认地址 `http://192.168.0.5`，导致连接一个几乎肯定错误的 IP 并超时，而不是提示用户提供网关地址。

每个家庭的网关地址都不同，`192.168.0.5` 对绝大多数用户都是错的。正确行为应是：首次连接且无地址可用时，先明确提示用户提供地址。

## 改动

- `src/mcp/config.ts`：移除 `DEFAULT_CONFIG.GATEWAY_URL` 硬编码默认值；`getConfig` 在无参数、无环境变量时返回空字符串。
- `src/core/gateway/manager.ts`：`connect` 无地址时抛出明确错误，不再回退到 `http://192.168.0.5`。
- `src/mcp/tools/auth.ts`：`mijia_auth` 在无地址时返回引导错误，提示提供 `gateway_url` 参数或设置 `GATEWAY_URL`；更新工具描述与参数说明。
- 新增 `src/mcp/config.test.ts` 回归测试。

## 保留项

Web 模式的 `.env.example` 与 `next.config.js` 中的示例地址保留 —— 那是给用户填写的模板，不影响 MCP 运行时行为。

## 验证

- `npx tsc --noEmit` 通过
- `npm run build:mcp` 通过
- `npx tsx src/mcp/config.test.ts` 通过（覆盖：缺省返回空、优先用参数、其次用环境变量）

## 行为变化说明

此改动会让"未配置网关地址"的场景从"静默连错误 IP 超时"变为"明确报错并引导用户提供地址"。对已正确设置 `GATEWAY_URL` 或传入 `gateway_url` 的用户无影响。
