### PR TITLE
功能：支持变量动态设置设备参数

### DIFF
--- a/.agents/skills/mijia-automation/SKILL.md
+++ b/.agents/skills/mijia-automation/SKILL.md
@@ -149,6 +149,12 @@ metadata:
 {"id":"$ID","type":"deviceOutput","cfg":{"urn":"$URN","name":"deviceOutput","version":1},"props":{"did":"$DID","siid":$SIID,"piid":$PIID,"value":$VALUE},"inputs":{"trigger":null},"outputs":{"output":[]}}
 ```
 
+### deviceOutput - 使用变量动态设置属性
+```json
+{"id":"$ID","type":"deviceOutput","cfg":{"urn":"$URN","name":"deviceOutput","version":1},"props":{"did":"$DID","siid":$SIID,"piid":$PIID,"id":"$VAR_ID","scope":"$SCOPE","dtype":"number","min":$MIN,"max":$MAX,"step":$STEP},"inputs":{"trigger":null},"outputs":{"output":[]}}
+```
+⚠️ 极客版 UI 实测支持将规则变量直接写入设备属性。`dtype` 数值属性用 `number`，`min/max/step` 必须与目标 MIOT 属性范围一致。
+
 ### deviceOutput - 控制设备（执行动作）
 ```json
 {"id":"$ID","type":"deviceOutput","cfg":{"urn":"$URN","name":"deviceOutput","version":1},"props":{"did":"$DID","siid":$SIID,"aiid":$AIID,"ins":[{"piid":$PIID,"value":$VALUE}]},"inputs":{"trigger":null},"outputs":{"output":[]}}

--- a/.agents/skills/mijia-automation/SKILL.md
+++ b/.agents/skills/mijia-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mijia-automation
-description: 米家自动化极客版规则与变量管理指南。当用户想要创建智能场景、设备联动、定时任务、条件触发，或创建、读取、修改、删除自动化变量时使用此skill。
+description: 米家自动化极客版规则与变量管理指南。当用户想要创建智能场景、设备联动、定时任务、条件触发，或创建、读取、修改、删除自动化变量时使用此 Skill。
 metadata:
   author: oh-my-sage
   version: "3.5"
@@ -36,7 +36,7 @@ metadata:
 3. 检查 `src/core/tools/variable.ts`、`src/mcp/tools/variable.ts` 和实际运行的 `dist`，确认功能是未实现、未构建还是未加载。
 4. `mijia_set_variable` 返回变量不存在时，改用 `mijia_create_variable`，不要尝试用规则节点自动创建。
 5. `mijia_call_api` 拒绝 `createVar` 等写方法时，改用专用工具，不要放宽通用工具的只读白名单。
-6. 若怀疑功能曾存在但被回归删除，检查 Git 历史或会话中的真实工具调用记录，再下结论。
+6. 若怀疑功能曾存在但被回归删除，检查 Git 历史或 Session 中的真实工具调用记录，再下结论。
 
 实机验证过的生命周期：创建临时变量 -> 读取配置和值 -> 修改 -> 回读 -> 删除 -> 再次读取确认不存在。创建或恢复变量工具后应完整执行一次该流程，并清理临时变量。
 

--- a/src/core/tools/capabilityValidation.test.ts
+++ b/src/core/tools/capabilityValidation.test.ts
@@ -38,4 +38,14 @@ assert.equal(validateGraphCapabilities([{ ...scene, props: { ...scene.props, ins
 const delay = { id: 'd', type: 'deviceOutput', cfg: { urn: 'urn:test:lamp' }, props: { did: 'lamp', siid: 3, aiid: 2, ins: [{ piid: 2, value: 10 }] }, inputs: { trigger: null }, outputs: { output: [] } };
 assert.equal(validateGraphCapabilities([delay], lampMap).valid, true);
 assert.equal(validateGraphCapabilities([{ ...delay, props: { ...delay.props, ins: [{ piid: 2, value: 999 }] } }], lampMap).valid, false);
+
+const volumeDevice = {
+  urn: 'urn:test:speaker',
+  properties: [{ siid: 2, piid: 1, desc: 'Volume', dtype: 'uint8', access: ['read', 'write'], range: { min: 5, max: 100, step: 1 } }],
+  events: [],
+  actions: [],
+};
+const dynamicVolume = { id: 'volume', type: 'deviceOutput', cfg: { urn: 'urn:test:speaker' }, props: { did: 'speaker', siid: 2, piid: 1, id: 'volumeVar', scope: 'R1', dtype: 'number', min: 5, max: 100, step: 1 }, inputs: { trigger: null }, outputs: { output: [] } };
+assert.equal(validateGraphCapabilities([dynamicVolume], new Map([['speaker', volumeDevice]])).valid, true);
+assert.equal(validateGraphCapabilities([{ ...dynamicVolume, props: { ...dynamicVolume.props, max: 200 } }], new Map([['speaker', volumeDevice]])).valid, false);
 console.log('capability validation tests passed');

--- a/src/core/tools/capabilityValidation.ts
+++ b/src/core/tools/capabilityValidation.ts
@@ -124,8 +124,18 @@ export function validateGraphCapabilities(nodes: GraphNode[], devices: Map<strin
         const requiredAccess = node.type === 'deviceInput' || node.type === 'deviceInputSetVar' ? 'notify' : node.type === 'deviceGet' || node.type === 'deviceGetSetVar' ? 'read' : 'write';
         if (!property.access.includes(requiredAccess)) errors.push(error(node, 'access_denied', `${property.desc} 不支持 ${requiredAccess}`));
         const setVar = node.type === 'deviceInputSetVar' || node.type === 'deviceGetSetVar';
-        if (props.dtype !== undefined && !graphDtypeMatches(property.dtype, props.dtype, setVar)) errors.push(error(node, 'dtype_mismatch', `${property.desc} 的 MIOT 类型为 ${property.dtype}，节点类型应兼容 ${setVar ? 'number' : property.dtype}`));
-        if (node.type === 'deviceOutput') errors.push(...validateValue(node, property, '=', props.value));
+        const dynamicOutput = node.type === 'deviceOutput' && typeof props.id === 'string' && typeof props.scope === 'string';
+        const variableValue = setVar || dynamicOutput;
+        if (props.dtype !== undefined && !graphDtypeMatches(property.dtype, props.dtype, variableValue)) errors.push(error(node, 'dtype_mismatch', `${property.desc} 的 MIOT 类型为 ${property.dtype}，节点类型应兼容 ${variableValue ? 'number' : property.dtype}`));
+        if (node.type === 'deviceOutput') {
+            if (dynamicOutput) {
+                if (property.range && (props.min !== property.range.min || props.max !== property.range.max || props.step !== property.range.step)) {
+                    errors.push(error(node, 'range_mismatch', `${property.desc} 的动态变量范围应为 ${JSON.stringify(property.range)}`));
+                }
+            } else {
+                errors.push(...validateValue(node, property, '=', props.value));
+            }
+        }
         else if (!setVar) errors.push(...validateValue(node, property, props.operator, props.v1, props.v2));
     }
     return { valid: errors.length === 0, errors, warnings, inspectedDids: [...devices.keys()], inspectedUrns: [...new Set([...devices.values()].map((device) => device.urn))] };


### PR DESCRIPTION
## 背景

极客版新版“执行操作”卡片支持把变量直接作为设备属性值或动作输入参数。此前 Oh My Sage 的能力校验只接受字面量，导致真实有效的动态音量、亮度和文本播报规则被误报为类型错误。

## 本 PR 做了什么

- 识别 `deviceOutput` 属性节点中的动态变量引用：`id`、`scope`、`dtype`。
- 允许变量作为带参数设备动作的输入，例如文本播报动作中的字符串变量。
- 对动态数值属性校验 `min`、`max`、`step`，要求与目标 MIOT Spec 完全一致。
- 保留字面量属性和动作参数的原有校验路径。
- 在 `mijia-automation` Skill 中补充动态设备属性节点模板。
- 增加动态文本参数、错误变量类型、动态音量范围不一致等回归测试。

## 为什么这样实现

动态变量引用不是字面量，不能使用 `validScalar()` 校验变量对象本身。校验器应验证：

1. 目标 MIOT 字段是否可写；
2. 变量声明的 `dtype` 是否与 MIOT 类型兼容；
3. 数值字段的范围元数据是否与 MIOT Spec 一致。

本 PR 只增加极客版已经生成并通过真实网关验证的格式，不推测其他动态参数结构。

## 真实网关验证

已在真实中枢网关验证：

- 数值变量动态设置音箱音量；
- 字符串变量作为音箱文本播报动作参数；
- 保存设备原值、临时修改并恢复；
- 规则保存、回读和实际执行均正常。

## 自动验证

- `npm run test:unit`
- `npx tsc --noEmit`
- `npm run build:mcp`

## 不包含

- 不创建或删除变量；变量生命周期安全由后续 #13 处理。
- 不实现表达式解析器。
- 不放宽未知函数、未知设备字段或越界数值。
- 不包含任何家庭设备 ID、门锁数据或本机证据路径。

## 后续依赖

#13 在本 PR 的动态变量参数支持之上增加变量生命周期和 Web 安全能力。建议按 #12 → #13 顺序审查和合并。