### PR TITLE
修复：复杂规则草稿在多进程下被静默覆盖

### DIFF
--- a/src/mcp/tools/graphDraft.ts
+++ b/src/mcp/tools/graphDraft.ts
@@ -38,6 +38,7 @@ function clone<T>(value: T): T {
 export class GraphDraftStore {
     private readonly drafts = new Map<string, GraphDraft>();
     private readonly activeCommits = new Map<string, string>();
+    private readonly removed = new Set<string>();
     private readonly cleanupTimer: NodeJS.Timeout;
 
     constructor(private readonly storePath = DEFAULT_STORE_PATH) {
@@ -151,6 +152,7 @@ export class GraphDraftStore {
 
     delete(id: string): boolean {
         const deleted = this.drafts.delete(id);
+        this.removed.add(id);
         if (deleted) this.persist();
         return deleted;
     }
@@ -192,27 +194,42 @@ export class GraphDraftStore {
         for (const [id, draft] of this.drafts) {
             if (draft.updatedAt < cutoff) {
                 this.drafts.delete(id);
+                this.removed.add(id);
                 changed = true;
             }
         }
         if (changed) this.persist();
     }
 
-    private load(): void {
+    private readStore(): Record<string, GraphDraft> {
         try {
-            const parsed = JSON.parse(fs.readFileSync(this.storePath, 'utf8')) as Record<string, GraphDraft>;
-            for (const [id, draft] of Object.entries(parsed)) this.drafts.set(id, draft);
-            this.prune();
+            return JSON.parse(fs.readFileSync(this.storePath, 'utf8')) as Record<string, GraphDraft>;
         } catch (error) {
-            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') console.error('[GraphDraft] 恢复草稿失败', error);
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') console.error('[GraphDraft] 读取草稿失败', error);
+            return {};
+        }
+    }
+
+    private load(): void {
+        const cutoff = Date.now() - DRAFT_TTL_MS;
+        for (const [id, draft] of Object.entries(this.readStore())) {
+            if (draft.updatedAt >= cutoff) this.drafts.set(id, draft);
         }
     }
 
     private persist(): void {
         const directory = path.dirname(this.storePath);
         fs.mkdirSync(directory, { recursive: true });
+        // ponytail: last-write-wins merge, switch to a file lock if drafts ever need cross-process edits of the same id
+        const cutoff = Date.now() - DRAFT_TTL_MS;
+        const merged: Record<string, GraphDraft> = {};
+        for (const [id, draft] of Object.entries(this.readStore())) {
+            if (this.removed.has(id) || this.drafts.has(id) || draft.updatedAt < cutoff) continue;
+            merged[id] = draft;
+        }
+        for (const [id, draft] of this.drafts) merged[id] = draft;
         const temporary = `${this.storePath}.${process.pid}.tmp`;
-        fs.writeFileSync(temporary, JSON.stringify(Object.fromEntries(this.drafts)));
+        fs.writeFileSync(temporary, JSON.stringify(merged));
         fs.renameSync(temporary, this.storePath);
     }
 }

--- a/tests/mcp/graphDraft.test.ts
+++ b/tests/mcp/graphDraft.test.ts
@@ -27,6 +27,18 @@ test('复杂规则草稿分块追加并保留节点顺序', () => withStore((dra
     assert.deepEqual(drafts.status(id).nodeIds, ['a', 'b', 'c']);
 }));
 
+test('并发进程共用草稿文件时不会互相覆盖', () => withStore((first, file) => {
+    const second = new GraphDraftStore(file);
+    const firstId = first.begin({ name: 'first' });
+    const secondId = second.begin({ name: 'second' });
+    first.append(firstId, [node('a')]);
+    second.append(secondId, [node('b')]);
+
+    const restored = new GraphDraftStore(file);
+    assert.deepEqual(restored.status(firstId).nodeIds, ['a']);
+    assert.deepEqual(restored.status(secondId).nodeIds, ['b']);
+}));
+
 test('相同节点重试幂等，内容变化时要求编辑', () => withStore((drafts) => {
     const id = drafts.begin({ name: 'test' });
     drafts.append(id, [node('same')]);


### PR DESCRIPTION
## 问题

`GraphDraftStore.persist()` 把内存中的草稿 Map 整体写盘。当两个 MCP 进程共用同一个草稿文件时（用户同时开多个 OpenCode 会话），后写入的进程会覆盖掉先创建的草稿，正在分块上传的复杂规则会静默丢失，没有任何报错。

## 复现

```
进程 A: begin(draftA) -> append(draftA, [...])
进程 B: begin(draftB) -> append(draftB, [...])
重启后读取: draftA 不存在
```

## 修改

- `persist()` 写盘前先读取磁盘内容并合并，只覆盖本进程持有的条目。
- 新增 `removed` 集合，记录本进程主动删除和过期清理的 ID，避免被合并逻辑复活。
- `load()` 拆出 `readStore()`，加载时直接按 TTL 过滤，不再依赖 `prune()` 的副作用写盘。

## 测试

新增回归测试「并发进程共用草稿文件时不会互相覆盖」，修复前失败、修复后通过。

- 单元测试: 66 项，65 通过，1 跳过（Windows 符号链接）
- `npx tsc --noEmit`: 通过
- `npm run lint`: 通过
- `npm run build:mcp`: 通过

## 已知边界

同一个草稿 ID 被两个进程同时编辑时仍是后写入者优先，代码中已用 `ponytail:` 注释标注，需要时可升级为文件锁。当前每个草稿只由创建它的会话操作，不构成实际风险。
