### PR TITLE
修复：查不到的设备ID不再伪装成离线设备

### DIFF
--- a/src/core/tools/device.ts
+++ b/src/core/tools/device.ts
@@ -182,12 +182,13 @@ export async function getDevice(gateway: GatewayClient, dids: string[]): Promise
         for (const did of dids) {
             const device = devList[did];
             if (!device) {
-                results.push({ did, name: '', model: '', modelName: '', online: false, roomName: '', urn: '' });
+                results.push({ did, found: false, name: '', model: '', modelName: '', online: false, roomName: '', urn: '' });
                 continue;
             }
 
             const info: DeviceInfo = {
                 did,
+                found: true,
                 name: device.name,
                 model: device.model,
                 modelName: device.modelName,

--- a/src/core/types/device.ts
+++ b/src/core/types/device.ts
@@ -52,6 +52,8 @@ export interface MiotActionCapability {
 /** 设备详情信息 */
 export interface DeviceInfo {
     did: string;
+    /** 该 did 是否存在于网关设备表。false 时其余字段均为占位空值，不代表设备离线 */
+    found: boolean;
     name: string;
     model: string;
     modelName: string;

--- a/src/mcp/tools/device.ts
+++ b/src/mcp/tools/device.ts
@@ -96,11 +96,13 @@ Args:
 
 Returns:
   - devices: 设备详情列表
+  - notFound: 网关设备表中不存在的设备ID列表（为空表示全部命中）
   - 包含 properties(所有字段约束), events(事件及参数), triggers, actions(含输入参数), readable
+  - 每个设备含 found 字段：false 表示该ID在网关设备表中不存在，其余字段为占位空值
 
 Error Handling:
   - "网关未连接" - 请先调用 mijia_auth
-  - "设备不存在" - 指定的设备ID不存在`,
+  - 设备ID不存在时不报错，而是在该设备的 found=false 并列入 notFound；请勿把它当作「设备离线」`,
       inputSchema: z.object({
         dids: z.array(z.string()).min(1).describe("设备ID数组"),
         response_format: ResponseFormatSchema.optional().default("markdown").describe("输出格式"),
@@ -125,7 +127,8 @@ Error Handling:
         }
 
         const devices = result.data ?? [];
-        const output = { devices, count: devices.length };
+        const notFound = devices.filter((device) => device.found === false).map((device) => device.did);
+        const output = { devices, count: devices.length, notFound };
 
         if (response_format === "json") {
           return {

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -103,6 +103,7 @@ export function formatDeviceListMarkdown(devices: Array<{
 export function formatDeviceDetailsMarkdown(devices: Array<{
   name: string;
   did: string;
+  found?: boolean;
   model?: string;
   modelName?: string;
   online?: boolean;
@@ -122,6 +123,15 @@ export function formatDeviceDetailsMarkdown(devices: Array<{
   const lines = ["## 设备详情", ""];
 
   for (const device of devices) {
+    if (device.found === false) {
+      lines.push(`### ${device.did}`);
+      lines.push("- ⚠️ 网关设备表中不存在该设备ID，无法读取任何能力");
+      lines.push("- 这不是「设备离线」：离线设备仍会返回名称、型号和 MIOT 能力");
+      lines.push("- 请核对设备ID是否正确，或该设备是否已从网关移除");
+      lines.push("");
+      continue;
+    }
+
     lines.push(`### ${device.name} (${device.did})`);
     lines.push(`- 型号: ${device.model || "未知"} - ${device.modelName || "未知"}`);
     lines.push(`- 状态: ${device.online ? "在线 ✅" : "离线 ❌"}`);

--- a/tests/core/device.test.ts
+++ b/tests/core/device.test.ts
@@ -59,3 +59,33 @@ test('解析同一 service 的事件参数并为缺失属性提供 fallback', as
         globalThis.fetch = originalFetch;
     }
 });
+
+test('网关设备表中不存在的设备ID标记为 found=false，且不与离线设备混淆', async () => {
+    const gateway = {
+        callApi: async () => ({
+            devList: {
+                offlineDev: {
+                    name: '已离线设备',
+                    model: 'test.offline',
+                    modelName: '测试离线设备',
+                    online: false,
+                    roomName: '测试房间',
+                    urn: '',
+                },
+            },
+        }),
+    } as unknown as GatewayClient;
+
+    const result = await getDevice(gateway, ['offlineDev', 'missingDev']);
+    assert.equal(result.success, true);
+
+    const offline = result.data?.find((device) => device.did === 'offlineDev');
+    assert.equal(offline?.found, true, '离线设备仍然存在于设备表，found 必须为 true');
+    assert.equal(offline?.online, false);
+    assert.equal(offline?.name, '已离线设备');
+
+    const missing = result.data?.find((device) => device.did === 'missingDev');
+    assert.equal(missing?.found, false, '设备表中不存在的 ID 必须标记 found=false');
+    assert.equal(missing?.online, false);
+    assert.equal(missing?.name, '');
+});

--- a/tests/mcp/utils.test.ts
+++ b/tests/mcp/utils.test.ts
@@ -24,3 +24,20 @@ test('Markdown 展示事件 ID 和参数取值', () => {
     assert.match(markdown, /参数 piid=1: button-id, uint8/);
     assert.match(markdown, /left/);
 });
+
+test('Markdown 对不存在的设备ID给出明确提示，不伪装成离线设备', () => {
+    const markdown = formatDeviceDetailsMarkdown([{
+        name: '',
+        did: 'missingDev',
+        found: false,
+        model: '',
+        modelName: '',
+        online: false,
+        roomName: '',
+    }]);
+
+    assert.match(markdown, /不存在该设备ID/);
+    assert.match(markdown, /这不是「设备离线」/);
+    assert.doesNotMatch(markdown, /离线 ❌/, '不得渲染成普通离线设备');
+    assert.doesNotMatch(markdown, /型号: 未知/, '不得渲染出会被误读为真实设备的占位型号');
+});


### PR DESCRIPTION
## 这个 PR 在解决什么

查询一个**不存在的设备 ID** 时，`mijia_get_device` 不报错，而是返回一条所有字段都是空的记录。这条记录渲染出来长这样：

```
###  (blt.3.1abcdefg0000)
- 型号: 未知 - 未知
- 状态: 离线 ❌
- 房间: 未分组
```

问题在于：**这和一台真实的离线设备看起来一模一样。**

## 这会造成什么

我在排查一条规则时查了它引用的设备 ID，看到上面这段输出，得出结论「这个设备已经从网关移除了，所以这条规则是失效的」，并据此向用户建议清理规则。

用户回复：这条规则明明在正常工作。

我拿一个"查不到"当成了"设备已被移除"，进而当成了"规则已失效"。整条推理链从第一步就错了，而输出本身没有给出任何提示让我意识到这一点。

真实场景里这两件事需要完全不同的处理：

| 情况 | 该做什么 |
|---|---|
| 设备离线 | 等它上线；规则本身没问题 |
| ID 在设备表里不存在 | 检查 ID 是否写错，或设备是否已解绑 |

而现在的输出把两者压成了同一个样子。

## 还有一处文档和行为对不上

`mijia_get_device` 的工具描述里写着：

```
Error Handling:
  - "设备不存在" - 指定的设备ID不存在
```

但代码里从来不会产生这个错误。调用方按描述去处理错误分支，永远等不到。

## 改了什么

### 1. `DeviceInfo` 增加 `found` 字段

```ts
export interface DeviceInfo {
    did: string;
    /** 该 did 是否存在于网关设备表。false 时其余字段均为占位空值，不代表设备离线 */
    found: boolean;
    ...
}
```

`getDevice` 在两条分支上分别置 `false` 和 `true`。

### 2. Markdown 对查不到的 ID 给出明确提示

不再渲染成"离线设备"，而是：

```
### blt.3.1abcdefg0000
- ⚠️ 网关设备表中不存在该设备ID，无法读取任何能力
- 这不是「设备离线」：离线设备仍会返回名称、型号和 MIOT 能力
- 请核对设备ID是否正确，或该设备是否已从网关移除
```

第二行是刻意加的——它直接堵住我犯过的那个推理错误。

### 3. MCP 响应增加 `notFound` 列表

```json
{ "devices": [...], "count": 2, "notFound": ["blt.3.1abcdefg0000"] }
```

批量查询时不用逐条翻 `found` 字段。全部命中时是空数组。

### 4. 修正工具描述

把不存在的"设备不存在"错误改成对实际行为的说明，并明确提示不要当作设备离线。

## 测试

新增两项，都是先确认修改前会失败：

**`tests/core/device.test.ts`** — 同一次查询里放一台**真实离线设备**和一个**不存在的 ID**，断言前者 `found=true`（离线不影响存在性）、后者 `found=false`。这一项专门守住"离线"和"不存在"不能混淆。

**`tests/mcp/utils.test.ts`** — 断言 Markdown 输出包含明确提示，且**不含** `离线 ❌` 和 `型号: 未知`，防止以后有人把渲染改回容易被误读的样子。

## 验证

- `npm run test:unit`：68 项，67 通过，1 跳过（Windows 符号链接）
- `npx tsc --noEmit`：通过
- `npm run lint`：通过
- `npm run build:mcp`：通过
- `npm run build`：通过

## 兼容性

`found` 是新增的必填字段，只在 `getDevice` 内部构造，没有其他构造点。Markdown 和 JSON 都是增量输出，原有字段保持不变，已有调用方不受影响。

## 没有做的

- 没有改成抛错或返回 `success: false`。批量查询里部分命中是正常场景，整体失败会让调用方更难处理。
- 没有区分「从未存在」和「曾经存在但已解绑」——网关的 `getDevList` 不提供这个信息。
