### PR TITLE
feat: 在设备详情中输出完整 URN

### DIFF
--- a/src/mcp/tools/device.ts
+++ b/src/mcp/tools/device.ts
@@ -88,7 +88,7 @@ Error Handling:
       title: "获取设备详情",
       description: `获取指定设备的详细信息，包括 MIOT Spec 能力定义。
 
-返回完整 MIOT Spec 能力：所有属性的读写订阅权限、类型、单位、枚举取值、数值范围，以及事件参数和动作输入参数。排查设备映射时优先使用本工具，无需先读取日志。
+返回完整 MIOT Spec 能力：所有属性的读写订阅权限、类型、单位、枚举取值、数值范围，以及事件参数和动作输入参数。同时返回该设备的完整 URN，构造规则节点的 cfg.urn 时直接使用，不要从型号字符串推导版本号。排查设备映射时优先使用本工具，无需先读取日志。
 
 Args:
   - dids (string[]): 设备ID数组，支持批量查询
@@ -97,6 +97,7 @@ Args:
 Returns:
   - devices: 设备详情列表
   - notFound: 网关设备表中不存在的设备ID列表（为空表示全部命中）
+  - 每个设备含 urn: 完整 MIOT URN，规则节点 cfg.urn 必须与之完全一致
   - 包含 properties(所有字段约束), events(事件及参数), triggers, actions(含输入参数), readable
   - 每个设备含 found 字段：false 表示该ID在网关设备表中不存在，其余字段为占位空值
 

--- a/src/mcp/utils.test.ts
+++ b/src/mcp/utils.test.ts
@@ -4,6 +4,7 @@ import { formatDeviceDetailsMarkdown } from './utils.js';
 const output = formatDeviceDetailsMarkdown([{
   did: 'sensor-1',
   name: 'Motion Sensor',
+  urn: 'urn:miot-spec-v2:device:motion-sensor:0000A014:lumi-bmgl01:1',
   properties: [{
     siid: 2, piid: 2, desc: 'Motion Sensor-No Motion Duration', dtype: 'uint16',
     access: ['read', 'notify'], unit: 'minutes', list: [{ value: 2, description: '2 Minutes' }],
@@ -19,4 +20,9 @@ assert.match(output, /unit=minutes/);
 assert.match(output, /values=\[{"value":2,"description":"2 Minutes"}\]/);
 assert.match(output, /range=\{"min":1,"max":100,"step":1\}/);
 assert.match(output, /参数 piid=3: Light-Brightness/);
+assert.match(output, /- URN: urn:miot-spec-v2:device:motion-sensor:0000A014:lumi-bmgl01:1/);
+
+const withoutUrn = formatDeviceDetailsMarkdown([{ did: 'plain-1', name: 'Plain Device' }]);
+assert.match(withoutUrn, /- URN: 未知/);
+
 console.log('device Markdown formatting tests passed');

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -108,6 +108,7 @@ export function formatDeviceDetailsMarkdown(devices: Array<{
   modelName?: string;
   online?: boolean;
   roomName?: string;
+  urn?: string;
   properties?: MiotPropertyCapability[];
   events?: MiotEventCapability[];
   triggers?: Array<{
@@ -136,6 +137,7 @@ export function formatDeviceDetailsMarkdown(devices: Array<{
     lines.push(`- 型号: ${device.model || "未知"} - ${device.modelName || "未知"}`);
     lines.push(`- 状态: ${device.online ? "在线 ✅" : "离线 ❌"}`);
     lines.push(`- 房间: ${device.roomName || "未分组"}`);
+    lines.push(`- URN: ${device.urn || "未知"}`);
     lines.push("");
 
     if (device.properties && device.properties.length > 0) {


### PR DESCRIPTION
## 问题

网关 `getDevList` 本就返回每台设备的 `urn`，`getDevice` 也已将其写入 `DeviceInfo`，但 `formatDeviceDetailsMarkdown` 的入参类型没有声明该字段，输出里也没有这一行。结果是数据取到了却没交给调用方。

## 为什么重要

规则节点的 `cfg.urn` 必须与设备 URN 完全一致，而 URN 尾部的版本号无法从型号字符串推导。同一网关下实测三台设备：

| 型号 | 完整 URN 尾部 |
|---|---|
| `chuangmi.camera.061a01` | `chuangmi-061a01:3` |
| `xiaomi.camera.083ac1` | `xiaomi-083ac1:2:0000D070` |
| `xiaomi.gateway.hub1` | `xiaomi-hub1:3` |

版本号既不固定为 1，也与型号无关，甚至同为摄像机类目也不一致。

在此之前，获取 URN 的唯一途径是构造只含目标节点的最小 graph、故意填错 URN 调用 `mijia_validate_graph_capabilities`，再从错误响应的 `inspectedUrns` 读取真实值。每接入一个新型号都要先付出一次失败调用。

## 改动

只把已有数据暴露出来，不改数据获取路径：

- `formatDeviceDetailsMarkdown` 入参类型补 `urn?: string`
- 输出增加 `- URN: ...` 一行，缺省显示「未知」
- `mijia_get_device` 的工具描述说明该字段用途，并提示不要从型号推导版本号

## 测试

`src/mcp/utils.test.ts` 补两条断言，覆盖有 URN 与缺省两种情况。

```
npx tsc --noEmit                       # 通过
npx tsx --test src/**/*.test.ts        # 4 passed / 0 failed
```

## 兼容性

纯增量。JSON 输出路径本就包含 `urn`，未受影响；Markdown 输出多一行，不影响既有字段的解析。