### PR TITLE
feat: 新增设备引用扫描工具 mijia_find_device_usage

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -10,7 +10,7 @@ export type { GatewayManager } from './gateway/manager';
 
 // 工具函数
 export { getDevices, getDevice } from './tools/device';
-export { getGraphs, getGraph, createGraph, updateGraph, deleteGraph, toggleGraph } from './tools/graph';
+export { getGraphs, getGraph, createGraph, updateGraph, deleteGraph, toggleGraph, findDeviceUsage } from './tools/graph';
 export { getVariables, setVariable, createVariable, deleteVariable, getVariableValue, getVariableConfig } from './tools/variable';
 export { callGatewayApi, READ_ONLY_GATEWAY_METHODS } from './tools/misc';
 export { validateGraphCapabilitiesWithGateway } from './tools/capabilityValidation';
@@ -27,5 +27,5 @@ export type {
     MiotValueListItem,
     MiotValueRange,
 } from './types/device';
-export type { Graph, GraphNode, GraphConfig, GraphSummary, CreateGraphInput, UpdateGraphInput, ValidationError } from './types/graph';
+export type { Graph, GraphNode, GraphConfig, GraphSummary, CreateGraphInput, UpdateGraphInput, ValidationError, DeviceUsageNode, DeviceUsageGraph, DeviceUsage, DeviceUsageReport } from './types/graph';
 export type { ToolResult, ToolError, ToolResponse, Variable } from './types';

--- a/src/core/tools/graph.ts
+++ b/src/core/tools/graph.ts
@@ -4,7 +4,8 @@
 
 import { GatewayClient } from '../gateway/client';
 import { randomInt } from 'node:crypto';
-import type { Graph, GraphSummary, CreateGraphInput, UpdateGraphInput, ValidationError } from '../types/graph';
+import type { Graph, GraphNode, GraphSummary, CreateGraphInput, UpdateGraphInput, ValidationError, DeviceUsageNode, DeviceUsageReport, DeviceUsage } from '../types/graph';
+import type { DeviceListResponse } from '../types/device';
 import type { ToolResponse } from '../types';
 import { validateGraph, layoutNodes } from './base';
 import { validateGraphCapabilitiesWithGateway } from './capabilityValidation';
@@ -345,3 +346,113 @@ export async function toggleGraph(gateway: GatewayClient, id: string, enable: bo
         return { success: false, error: `切换规则状态失败: ${error}` };
     }
 }
+
+// ==================== 设备引用扫描 ====================
+
+/** 会携带 did 的节点类型 → 该设备在节点中扮演的角色 */
+const DEVICE_NODE_ROLES: Record<string, DeviceUsageNode['role']> = {
+    deviceInput: 'trigger',
+    deviceInputSetVar: 'trigger',
+    deviceGet: 'read',
+    deviceGetSetVar: 'read',
+    deviceOutput: 'write',
+};
+
+function nodeTarget(props: GraphNode['props']): string {
+    const parts = (['siid', 'piid', 'eiid', 'aiid'] as const)
+        .filter((key) => typeof props[key] === 'number')
+        .map((key) => `${key}=${String(props[key])}`);
+    return parts.join(' ') || '-';
+}
+
+/**
+ * 扫描全部规则，找出引用了指定设备的规则与节点。
+ * 传入的 did 即使已从网关设备表中删除也会照常扫描，用于排查残留引用。
+ * 需要逐条拉取规则，规则较多时耗时数秒。
+ */
+export async function findDeviceUsage(
+    gateway: GatewayClient,
+    input: { dids?: string[]; query?: string }
+): Promise<ToolResponse<DeviceUsageReport>> {
+    const explicitDids = (input.dids || []).map((did) => did.trim()).filter(Boolean);
+    const query = input.query?.trim().toLowerCase() || '';
+    if (explicitDids.length === 0 && !query) {
+        return { success: false, error: '必须提供 dids 或 query 之一' };
+    }
+
+    try {
+        const deviceResponse = await gateway.callApi<DeviceListResponse>('getDevList', {}, 10000);
+        const devList = deviceResponse.devList || {};
+
+        const targets = new Map<string, { name: string; found: boolean }>();
+        for (const did of explicitDids) {
+            const device = devList[did];
+            targets.set(did, { name: device?.name || '(设备表中不存在)', found: Boolean(device) });
+        }
+        if (query) {
+            for (const [did, device] of Object.entries(devList)) {
+                const haystack = `${did} ${device.name} ${device.model} ${device.modelName} ${device.roomName}`.toLowerCase();
+                if (haystack.includes(query)) targets.set(did, { name: device.name, found: true });
+            }
+        }
+        if (targets.size === 0) {
+            return { success: false, error: `没有匹配 "${input.query}" 的设备，请改用 mijia_get_devices 确认名称` };
+        }
+
+        const graphList = await gateway.callApi<Array<{ id: string; enable?: boolean; userData?: { name?: string } }>>('getGraphList', {}, 10000);
+        const summaries = Array.isArray(graphList) ? graphList : [];
+
+        const hits = new Map<string, DeviceUsage>();
+        for (const [did, info] of targets) {
+            hits.set(did, { did, name: info.name, found: info.found, nodeCount: 0, graphs: [] });
+        }
+        const orphanGraphs = new Map<string, string[]>();
+        const unreadableGraphs: string[] = [];
+
+        for (const summary of summaries) {
+            const graphName = summary.userData?.name || summary.id;
+            let nodes: GraphNode[];
+            try {
+                const graph = await gateway.callApi<Graph>('getGraph', { id: summary.id }, 10000);
+                nodes = graph.nodes || [];
+            } catch {
+                unreadableGraphs.push(summary.id);
+                continue;
+            }
+
+            const perDevice = new Map<string, DeviceUsageNode[]>();
+            for (const node of nodes) {
+                const role = DEVICE_NODE_ROLES[node.type];
+                const did = node.props?.did;
+                if (!role || typeof did !== 'string') continue;
+                if (!devList[did] && !orphanGraphs.has(did)) orphanGraphs.set(did, []);
+                if (!devList[did]) {
+                    const list = orphanGraphs.get(did)!;
+                    if (!list.includes(graphName)) list.push(graphName);
+                }
+                if (!hits.has(did)) continue;
+                if (!perDevice.has(did)) perDevice.set(did, []);
+                perDevice.get(did)!.push({ nodeId: node.id, nodeType: node.type, role, target: nodeTarget(node.props) });
+            }
+
+            for (const [did, usageNodes] of perDevice) {
+                const usage = hits.get(did)!;
+                usage.nodeCount += usageNodes.length;
+                usage.graphs.push({ graphId: summary.id, name: graphName, enable: summary.enable ?? false, nodes: usageNodes });
+            }
+        }
+
+        return {
+            success: true,
+            data: {
+                devices: [...hits.values()].sort((a, b) => b.nodeCount - a.nodeCount),
+                orphans: [...orphanGraphs].map(([did, graphs]) => ({ did, graphs })),
+                scannedGraphs: summaries.length,
+                unreadableGraphs,
+            },
+        };
+    } catch (error) {
+        return { success: false, error: `扫描设备引用失败: ${error}` };
+    }
+}
+

--- a/src/core/types/graph.ts
+++ b/src/core/types/graph.ts
@@ -68,3 +68,41 @@ export interface ValidationError {
     level: 'error' | 'warn';
     message: string;
 }
+
+/** 设备在某个节点上的使用方式 */
+export interface DeviceUsageNode {
+    nodeId: string;
+    nodeType: string;
+    /** trigger=被订阅触发, read=被读取判断, write=被写入控制 */
+    role: 'trigger' | 'read' | 'write';
+    /** 命中的 MIOT 定位，如 "siid=2 piid=1" */
+    target: string;
+}
+
+/** 单条规则中对某设备的引用 */
+export interface DeviceUsageGraph {
+    graphId: string;
+    name: string;
+    enable: boolean;
+    nodes: DeviceUsageNode[];
+}
+
+/** 单个设备的引用汇总 */
+export interface DeviceUsage {
+    did: string;
+    name: string;
+    /** 该 did 是否存在于网关设备表；false 表示设备已被删除但规则仍在引用 */
+    found: boolean;
+    nodeCount: number;
+    graphs: DeviceUsageGraph[];
+}
+
+/** 设备引用扫描报告 */
+export interface DeviceUsageReport {
+    devices: DeviceUsage[];
+    /** 规则引用了但网关设备表中已不存在的 did */
+    orphans: Array<{ did: string; graphs: string[] }>;
+    scannedGraphs: number;
+    /** 读取失败的规则，其引用情况未知 */
+    unreadableGraphs: string[];
+}

--- a/src/mcp/tools/device.ts
+++ b/src/mcp/tools/device.ts
@@ -5,13 +5,14 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { GatewayManager } from "../../core/gateway/manager.js";
-import { getDevices, getDevice } from "../../core/index.js";
+import { getDevices, getDevice, findDeviceUsage } from "../../core/index.js";
 import {
   ResponseFormatSchema,
   formatJson,
   handleError,
   formatDeviceListMarkdown,
   formatDeviceDetailsMarkdown,
+  formatDeviceUsageMarkdown,
 } from "../utils.js";
 
 export function registerDeviceTools(
@@ -145,6 +146,80 @@ Error Handling:
       } catch (error) {
         return {
           content: [{ type: "text", text: handleError(error, "get_device") }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ==================== mijia_find_device_usage ====================
+  server.registerTool(
+    "mijia_find_device_usage",
+    {
+      title: "查询设备被哪些自动化规则引用",
+      description: `一次扫描全部自动化规则，找出引用了指定设备的规则和节点。
+
+替代逐条 mijia_get_graph 翻查。更换、拆除、排查设备前先用本工具确认影响范围。
+
+Args:
+  - dids (string[], optional): 设备ID数组。已从网关删除的设备ID同样可查，用于排查残留引用
+  - query (string, optional): 名称/型号/房间/设备ID的模糊匹配，不区分大小写。型号同时匹配 model 串(如 linp-es5b)与中文型号名
+  - response_format (string, optional): 输出格式，默认 "markdown"
+  - dids 与 query 至少提供一个；两者同时提供时取并集
+
+Returns:
+  - devices: 每个设备命中的规则列表，含节点ID、节点类型、角色(trigger 触发 / read 读取 / write 控制)、siid/piid/eiid/aiid
+  - orphans: 规则引用了但网关设备表中已不存在的设备ID及其规则名，为空表示没有残留引用
+  - scannedGraphs: 本次扫描的规则总数
+  - unreadableGraphs: 读取失败的规则ID，非空说明这些规则的引用情况未确认
+
+Error Handling:
+  - "网关未连接" - 请先调用 mijia_auth
+  - "必须提供 dids 或 query 之一"
+  - query 无匹配时返回错误，请先用 mijia_get_devices 确认名称
+
+Note: 需要逐条拉取规则，规则较多时耗时数秒。`,
+      inputSchema: z.object({
+        dids: z.array(z.string()).optional().describe("设备ID数组"),
+        query: z.string().optional().describe("名称/型号/房间/设备ID模糊匹配"),
+        response_format: ResponseFormatSchema.optional().default("markdown").describe("输出格式"),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ dids, query, response_format = "markdown" }) => {
+      try {
+        gatewayManager.ensureConnected();
+        const result = await findDeviceUsage(gatewayManager.gateway!, { dids, query });
+
+        if (!result.success) {
+          return {
+            content: [{ type: "text", text: handleError(new Error(result.error), "find_device_usage") }],
+            isError: true,
+          };
+        }
+
+        const report = result.data ?? { devices: [], orphans: [], scannedGraphs: 0, unreadableGraphs: [] };
+        const output = { ...report };
+
+        if (response_format === "json") {
+          return {
+            content: [{ type: "text", text: formatJson(output) }],
+            structuredContent: output,
+          };
+        }
+
+        return {
+          content: [{ type: "text", text: formatDeviceUsageMarkdown(report) }],
+          structuredContent: output,
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: handleError(error, "find_device_usage") }],
           isError: true,
         };
       }

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -246,6 +246,61 @@ export function formatGraphListMarkdown(graphs: Array<{
 }
 
 /**
+ * 格式化设备引用扫描结果为 Markdown
+ */
+export function formatDeviceUsageMarkdown(report: {
+  devices: Array<{
+    did: string;
+    name: string;
+    found: boolean;
+    nodeCount: number;
+    graphs: Array<{
+      graphId: string;
+      name: string;
+      enable: boolean;
+      nodes: Array<{ nodeId: string; nodeType: string; role: string; target: string }>;
+    }>;
+  }>;
+  orphans: Array<{ did: string; graphs: string[] }>;
+  scannedGraphs: number;
+  unreadableGraphs: string[];
+}): string {
+  const ROLE_LABEL: Record<string, string> = { trigger: "触发", read: "读取", write: "控制" };
+  const lines = ["## 设备引用扫描", "", `扫描规则: ${report.scannedGraphs} 条`, ""];
+
+  for (const device of report.devices) {
+    lines.push(`### ${device.name} (${device.did})`);
+    if (!device.found) lines.push("- ⚠️ 该设备已不在网关设备表中");
+    if (device.graphs.length === 0) {
+      lines.push("- 没有任何规则引用此设备", "");
+      continue;
+    }
+    lines.push(`- 命中 ${device.graphs.length} 条规则，共 ${device.nodeCount} 个节点`, "");
+    for (const graph of device.graphs) {
+      lines.push(`- **${graph.name}** (${graph.graphId}) ${graph.enable ? "✅ 已启用" : "❌ 已禁用"}`);
+      for (const node of graph.nodes) {
+        lines.push(`  - ${node.nodeId} · ${node.nodeType} · ${ROLE_LABEL[node.role] || node.role} · ${node.target}`);
+      }
+    }
+    lines.push("");
+  }
+
+  if (report.orphans.length > 0) {
+    lines.push("### ⚠️ 残留引用（设备已删除但规则仍在引用）");
+    for (const orphan of report.orphans) {
+      lines.push(`- ${orphan.did} → ${orphan.graphs.join(", ")}`);
+    }
+    lines.push("");
+  }
+
+  if (report.unreadableGraphs.length > 0) {
+    lines.push("### ⚠️ 读取失败的规则（引用情况未知）", `- ${report.unreadableGraphs.join(", ")}`, "");
+  }
+
+  return lines.join("\n");
+}
+
+/**
  * 格式化变量列表为 Markdown
  */
 export function formatVariableListMarkdown(

--- a/tests/core/deviceUsage.test.ts
+++ b/tests/core/deviceUsage.test.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { GatewayClient } from '../../src/core/gateway/client';
+import { findDeviceUsage } from '../../src/core/tools/graph';
+
+const DEV_LIST = {
+    devList: {
+        lampA: { name: '客厅吸顶灯', model: 'pmfbj.light.a', modelName: '松下吸顶灯', online: true, roomName: '客厅', urn: 'urn:a' },
+        sensorA: { name: '客厅人在传感器', model: 'linp.sensor.es5', modelName: '领普存在传感器', online: true, roomName: '客厅', urn: 'urn:b' },
+        speakerA: { name: '主卧音箱', model: 'xiaomi.speaker', modelName: '小米音箱', online: true, roomName: '主卧', urn: 'urn:c' },
+    },
+};
+
+const GRAPH_LIST = [
+    { id: 'g1', enable: true, userData: { name: '客厅灯控' } },
+    { id: 'g2', enable: false, userData: { name: '旧规则_BAK' } },
+    { id: 'g3', enable: true, userData: { name: '主卧播报' } },
+];
+
+const GRAPHS: Record<string, { nodes: Array<Record<string, unknown>> }> = {
+    g1: {
+        nodes: [
+            { id: 'trig', type: 'deviceInput', cfg: {}, props: { did: 'sensorA', siid: 2, piid: 1078 }, inputs: {}, outputs: {} },
+            { id: 'read', type: 'deviceGet', cfg: {}, props: { did: 'lampA', siid: 2, piid: 1 }, inputs: {}, outputs: {} },
+            { id: 'on', type: 'deviceOutput', cfg: {}, props: { did: 'lampA', siid: 2, piid: 1 }, inputs: {}, outputs: {} },
+            { id: 'wait', type: 'delay', cfg: {}, props: { timeout: 1000 }, inputs: {}, outputs: {} },
+        ],
+    },
+    g2: {
+        nodes: [
+            { id: 'ghost', type: 'deviceOutput', cfg: {}, props: { did: 'deletedCam', siid: 10, piid: 2 }, inputs: {}, outputs: {} },
+        ],
+    },
+    g3: {
+        nodes: [
+            { id: 'say', type: 'deviceOutput', cfg: {}, props: { did: 'speakerA', siid: 7, aiid: 3 }, inputs: {}, outputs: {} },
+        ],
+    },
+};
+
+function stubGateway(overrides: { unreadable?: string[] } = {}): GatewayClient {
+    return {
+        callApi: async (method: string, params?: Record<string, unknown>) => {
+            if (method === 'getDevList') return DEV_LIST;
+            if (method === 'getGraphList') return GRAPH_LIST;
+            if (method === 'getGraph') {
+                const id = String(params?.id);
+                if (overrides.unreadable?.includes(id)) throw new Error('timeout');
+                return GRAPHS[id];
+            }
+            throw new Error(`unexpected method ${method}`);
+        },
+    } as unknown as GatewayClient;
+}
+
+test('按 did 查询命中规则、节点与角色', async () => {
+    const result = await findDeviceUsage(stubGateway(), { dids: ['lampA'] });
+    assert.equal(result.success, true);
+    if (!result.success) return;
+
+    const lamp = result.data!.devices.find((device) => device.did === 'lampA');
+    assert.equal(lamp?.found, true);
+    assert.equal(lamp?.name, '客厅吸顶灯');
+    assert.equal(lamp?.nodeCount, 2);
+    assert.equal(lamp?.graphs.length, 1);
+    assert.equal(lamp?.graphs[0].graphId, 'g1');
+    assert.equal(lamp?.graphs[0].enable, true);
+    assert.deepEqual(lamp?.graphs[0].nodes, [
+        { nodeId: 'read', nodeType: 'deviceGet', role: 'read', target: 'siid=2 piid=1' },
+        { nodeId: 'on', nodeType: 'deviceOutput', role: 'write', target: 'siid=2 piid=1' },
+    ]);
+    assert.equal(result.data!.scannedGraphs, 3);
+});
+
+test('非设备节点不计入引用', async () => {
+    const result = await findDeviceUsage(stubGateway(), { dids: ['lampA'] });
+    assert.equal(result.success, true);
+    if (!result.success) return;
+    const nodeIds = result.data!.devices[0].graphs[0].nodes.map((node) => node.nodeId);
+    assert.equal(nodeIds.includes('wait'), false);
+});
+
+test('deviceInput 记为 trigger，动作节点 target 含 aiid', async () => {
+    const result = await findDeviceUsage(stubGateway(), { dids: ['sensorA', 'speakerA'] });
+    assert.equal(result.success, true);
+    if (!result.success) return;
+
+    const sensor = result.data!.devices.find((device) => device.did === 'sensorA');
+    assert.equal(sensor?.graphs[0].nodes[0].role, 'trigger');
+    assert.equal(sensor?.graphs[0].nodes[0].target, 'siid=2 piid=1078');
+
+    const speaker = result.data!.devices.find((device) => device.did === 'speakerA');
+    assert.equal(speaker?.graphs[0].nodes[0].target, 'siid=7 aiid=3');
+});
+
+test('query 按名称/房间模糊匹配，不区分大小写', async () => {
+    const byName = await findDeviceUsage(stubGateway(), { query: '吸顶灯' });
+    assert.equal(byName.success, true);
+    if (!byName.success) return;
+    assert.deepEqual(byName.data!.devices.map((device) => device.did), ['lampA']);
+
+    const byModel = await findDeviceUsage(stubGateway(), { query: 'LINP' });
+    assert.equal(byModel.success, true);
+    if (!byModel.success) return;
+    assert.deepEqual(byModel.data!.devices.map((device) => device.did), ['sensorA']);
+});
+
+test('已删除设备的 did 仍可扫描，found=false 且能查出残留引用', async () => {
+    const result = await findDeviceUsage(stubGateway(), { dids: ['deletedCam'] });
+    assert.equal(result.success, true);
+    if (!result.success) return;
+
+    const ghost = result.data!.devices[0];
+    assert.equal(ghost.found, false, '设备表中不存在必须标记 found=false');
+    assert.equal(ghost.graphs.length, 1);
+    assert.equal(ghost.graphs[0].name, '旧规则_BAK');
+    assert.equal(ghost.graphs[0].enable, false);
+    assert.deepEqual(result.data!.orphans, [{ did: 'deletedCam', graphs: ['旧规则_BAK'] }]);
+});
+
+test('无引用的设备返回空规则列表而不是报错', async () => {
+    const gateway = {
+        callApi: async (method: string) => {
+            if (method === 'getDevList') return DEV_LIST;
+            if (method === 'getGraphList') return [];
+            throw new Error(`unexpected method ${method}`);
+        },
+    } as unknown as GatewayClient;
+
+    const result = await findDeviceUsage(gateway, { dids: ['lampA'] });
+    assert.equal(result.success, true);
+    if (!result.success) return;
+    assert.equal(result.data!.devices[0].graphs.length, 0);
+    assert.equal(result.data!.devices[0].nodeCount, 0);
+    assert.equal(result.data!.scannedGraphs, 0);
+});
+
+test('单条规则读取失败时记入 unreadableGraphs 而不中断扫描', async () => {
+    const result = await findDeviceUsage(stubGateway({ unreadable: ['g1'] }), { dids: ['lampA', 'speakerA'] });
+    assert.equal(result.success, true);
+    if (!result.success) return;
+
+    assert.deepEqual(result.data!.unreadableGraphs, ['g1']);
+    const speaker = result.data!.devices.find((device) => device.did === 'speakerA');
+    assert.equal(speaker?.graphs.length, 1, '其余规则必须照常扫描');
+});
+
+test('dids 与 query 都未提供时报错', async () => {
+    const result = await findDeviceUsage(stubGateway(), {});
+    assert.equal(result.success, false);
+    if (result.success) return;
+    assert.match(result.error, /必须提供 dids 或 query/);
+});
+
+test('query 无匹配时报错并提示改用设备列表', async () => {
+    const result = await findDeviceUsage(stubGateway(), { query: '不存在的设备' });
+    assert.equal(result.success, false);
+    if (result.success) return;
+    assert.match(result.error, /没有匹配/);
+});


### PR DESCRIPTION
## 解决什么问题

排查某个设备被哪些自动化规则用到，此前只能 `mijia_get_graphs` 拿列表后逐条 `mijia_get_graph` 翻。规则一多就非常费时，且极易漏判——尤其是设备已从网关删除、规则里只剩一个 did 的情况，肉眼几乎看不出来。

## 做了什么

新增 MCP 工具 `mijia_find_device_usage`，一次扫描全部规则并汇总引用点。

- **两种查法**：`dids` 精确查询，`query` 对名称/型号(model 串与中文型号名)/房间/设备ID 做不区分大小写的模糊匹配；两者同时提供时取并集
- **已删除的设备照样能查**：`found=false` 但仍完整扫描，专门用于排查残留引用
- **节点级定位**：每个命中点给出节点ID、节点类型、角色（`trigger` 触发 / `read` 读取判断 / `write` 写入控制）以及 `siid/piid/eiid/aiid`
- **`orphans`**：顺带列出所有「规则在引用、但网关设备表中已不存在」的 did 及其规则名
- **`unreadableGraphs`**：单条规则读取失败时记入该字段并继续扫描，不会中断整体结果，也不会把「没读到」伪装成「没引用」

`markdown` 与 `json` 两种输出格式，只读工具。

## 实测

真实网关，38 条规则，扫描耗时约 **0.65 秒**。

抽查结果与手工核对一致：

- 新装摄像机命中 2 条规则（一条禁用的 `read`、一条启用的 `write`）
- 已从网关删除的旧摄像机 `found=false` 且 0 条引用
- `orphans` 查出 6 个残留 did，全部落在已禁用的 `_BAK` 规则中

## 测试

新增 `tests/core/deviceUsage.test.ts`，9 个用例覆盖：did 查询与角色映射、非设备节点不计入、aiid 定位、模糊匹配、已删除设备与 orphans、无引用返回空列表、单条规则读取失败的降级、两个入参校验分支。

`npm run test:unit` 全绿，`npx tsc --noEmit -p tsconfig.mcp.json` 与 `npm run lint` 均无输出。
